### PR TITLE
Add Google Analytics tracking code for WebTech property

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Global Site Tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-28203673-6"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments) };
+        gtag('js', new Date());
+        gtag('config', 'UA-28203673-6');
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
See title.

I think it's okay to hard-code the property ID for now instead of making it configurable. I can't foresee a situation in the near future where changing it will be necessary, and we can reevaluate this if it becomes necessary.