### PR TITLE
Prune updates older than one month

### DIFF
--- a/updater/updater.go
+++ b/updater/updater.go
@@ -73,10 +73,10 @@ func (u *Updater) Run() {
 	}
 }
 
-// Send a request to iTrak API, get updated shuttle info, and
-// finally store updated records in the database.
+// Send a request to iTrak API, get updated shuttle info,
+// store updated records in the database, and remove old records.
 func (u *Updater) update() {
-	// Make request to our tracking data feed
+	// Make request to iTrak data feed
 	client := http.Client{Timeout: time.Second * 5}
 	resp, err := client.Get(u.cfg.DataFeed)
 	if err != nil {
@@ -99,7 +99,8 @@ func (u *Updater) update() {
 
 	// TODO: Figure out if this handles == 1 vehicle correctly or always assumes > 1.
 	if len(vehiclesData) <= 1 {
-		log.Warnf("found no vehicles delineated by '%s'", delim)
+		log.Warnf("Found no vehicles delineated by '%s'", delim)
+		return
 	}
 
 	updated := 0
@@ -165,13 +166,21 @@ func (u *Updater) update() {
 
 		if err := u.db.Updates.Insert(&update); err != nil {
 			log.WithError(err).Errorf("Could not insert vehicle update.")
+			continue
 		} else {
 			updated++
 		}
 
-		// here if parsing error, updated will be incremented, wait, the whole thing will crash, isn't it?
 	}
 	log.Debugf("Successfully updated %d/%d vehicles.", updated, len(vehiclesData)-1)
+
+	// Prune updates older than one month
+	info, err := u.db.Updates.RemoveAll(bson.M{"created": bson.M{"$lt": time.Now().AddDate(0, -1, 0)}})
+	if err != nil {
+		log.WithError(err).Error("Unable to remove old updates.")
+		return
+	}
+	log.Debugf("Removed %d old updates.", info.Removed)
 }
 
 // Convert kmh to mph


### PR DESCRIPTION
This happens during each update loop. Alternative would be to set a TTL on an index in Mongo and let it garbage collect expired documents, but I think doing it application-side is more obvious.