### PR TITLE
Only store updates if iTrak data is changed

### DIFF
--- a/updater/updater.go
+++ b/updater/updater.go
@@ -188,7 +188,9 @@ func (u *Updater) update() {
 		log.WithError(err).Error("Unable to remove old updates.")
 		return
 	}
-	log.Debugf("Removed %d old updates.", info.Removed)
+	if info.Removed > 0 {
+		log.Debugf("Removed %d old updates.", info.Removed)
+	}
 }
 
 // Convert kmh to mph
@@ -205,10 +207,18 @@ func (u *Updater) LastUpdatesForVehicle(vehicle *model.Vehicle, count int) (upda
 	return
 }
 
+// RecentUpdatesForVehicle returns updates for a vehicle since the provided time.
+func (u *Updater) RecentUpdatesForVehicle(vehicle *model.Vehicle, since time.Time) (updates []model.VehicleUpdate) {
+	err := u.db.Updates.Find(bson.M{"vehicleID": vehicle.VehicleID, "created": bson.M{"$gt": since}}).All(&updates)
+	if err != nil {
+		log.Error(err)
+	}
+	return
+}
+
 // GuessRouteForVehicle returns a guess at what route the vehicle is on.
 // It may return an empty route if it does not believe a vehicle is on any route.
 func (u *Updater) GuessRouteForVehicle(vehicle *model.Vehicle) (route model.Route, err error) {
-	samples := 100
 	var routes []model.Route
 	err = u.db.Routes.Find(bson.M{}).All(&routes)
 	if err != nil {
@@ -220,7 +230,12 @@ func (u *Updater) GuessRouteForVehicle(vehicle *model.Vehicle) (route model.Rout
 		routeDistances[route.ID] = 0
 	}
 
-	updates := u.LastUpdatesForVehicle(vehicle, samples)
+	updates := u.RecentUpdatesForVehicle(vehicle, time.Now().Add(time.Minute*-15))
+	if len(updates) < 5 {
+		// Can't make a guess with fewer than 5 updates.
+		log.Debugf("%v has too few recent updates (%d) to guess route.", vehicle.VehicleName, len(updates))
+		return
+	}
 
 	for _, update := range updates {
 		updateLatitude, err := strconv.ParseFloat(update.Lat, 64)
@@ -255,7 +270,7 @@ func (u *Updater) GuessRouteForVehicle(vehicle *model.Vehicle) (route model.Rout
 	minDistance := math.Inf(0)
 	var minRouteID string
 	for id := range routeDistances {
-		distance := routeDistances[id] / float64(samples)
+		distance := routeDistances[id] / float64(len(updates))
 		if distance < minDistance {
 			minDistance = distance
 			minRouteID = id
@@ -266,13 +281,17 @@ func (u *Updater) GuessRouteForVehicle(vehicle *model.Vehicle) (route model.Rout
 			}
 		}
 	}
-	log.Debugf("%v distance from nearest route: %v\n", vehicle.VehicleName, minDistance)
 
 	// not on a route
 	if minRouteID == "" {
+		log.Debugf("%v not on route; distance from nearest: %v", vehicle.VehicleName, minDistance)
 		return model.Route{}, nil
 	}
 
 	err = u.db.Routes.Find(bson.M{"id": minRouteID}).One(&route)
+	if err != nil {
+		return route, err
+	}
+	log.Debugf("%v on %s route.", vehicle.VehicleName, route.Name)
 	return route, err
 }


### PR DESCRIPTION
Use timestamp data returned by iTrak for each vehicle to only create update documents for vehicles with new timestamps. Checks if the iTrak timestamp isn't equal to the most recent stored update.