### PR TITLE
Rework inactive vehicle detection

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -18,8 +18,7 @@ type VehicleUpdate struct {
 	Date      string    `json:"date"        bson:"date"`
 	Status    string    `json:"status"      bson:"status"`
 	Created   time.Time `json:"created"     bson:"created"`
-	Segment   string    `json:"segment"     bson:"segment"` // the segment that a vehicle resides on
-	Route			string		`json:"RouteID"			bson:"rotueID"`		
+	Route     string    `json:"RouteID"     bson:"routeID"`
 }
 
 // Vehicle represents an object being tracked.
@@ -28,7 +27,7 @@ type Vehicle struct {
 	VehicleName string    `json:"vehicleName" bson:"vehicleName"`
 	Created     time.Time `bson:"created"`
 	Updated     time.Time `bson:"updated"`
-	Active      bool      `json:"active"`
+	Enabled     bool      `json:"enabled"     bson:"enabled"`
 }
 
 // Status contains a detailed message on the tracked object's status.

--- a/static/js/vehicles.js
+++ b/static/js/vehicles.js
@@ -10,7 +10,7 @@ Vue.component('vehicle-create',{
     <b>id</b>: <input type="textbox" v-model="ID" placeholder="1123454125"></input> (must be same as itrak vehicle ID) <br>
     <b>name</b>:<input type="textbox" v-model="name" placeholder="Vehicle Name"></input> <br>
 
-    <b>active</b>:<input type="checkbox" v-model="active"></input><br>
+    <b>enabled</b>:<input type="checkbox" v-model="enabled"></input><br>
     <div class = "button" @click="send" style="width: 50px;">add</div>
 
     </div>`,
@@ -25,7 +25,7 @@ Vue.component('vehicle-create',{
     methods: {
       send: function(){
 
-        var pkg = {"vehicleID":this.ID, "vehicleName":this.name, "active":this.active};
+        var pkg = {"vehicleID":this.ID, "vehicleName":this.name, "enabled":this.enabled};
 
         pkg = JSON.stringify(pkg);
         $.ajax({
@@ -49,7 +49,7 @@ Vue.component('vehicle-card', {
   `<div class="vehicle-card route-description-box">
     <b>id</b>: {{info.vehicleID}}<br>
     <b>name</b>: <input type="textbox" v-model="info.vehicleName"></input> <br>
-    <b>active</b>: <input type="checkbox" v-model="info.active"></input>{{info.active}}<br>
+    <b>enabled</b>: <input type="checkbox" v-model="info.enabled"></input>{{info.enabled}}<br>
     <b>Created</b>: {{info.Created}} <br>
     <div @click="editVehicle" class = "button" style="width: auto; float:left;">change</div>
     <div @click="deleteVehicle" class = "button" style="width: auto; float:left;">delete</div>
@@ -75,7 +75,7 @@ Vue.component('vehicle-card', {
     editVehicle: function(){
       var el = this;
 
-      var pkg = {"vehicleID":this.info.vehicleID, "vehicleName":this.info.vehicleName, "active":this.info.active};
+      var pkg = {"vehicleID":this.info.vehicleID, "vehicleName":this.info.vehicleName, "enabled":this.info.enabled};
       $.ajax({
         url: "/vehicles/edit",
         type: "POST",


### PR DESCRIPTION
This changes the `/updates` endpoint to use most recent updates for each vehicle. Previously, the endpoint looped through each vehicle's last 20 updates to determine if it has been stationary for more than a few minutes, and then only returned the latest update for each non-stationary vehicle.

This is a lot of work to do on each request, but instead we can just look at the most recent update for each vehicle and return any that is from the last five minutes. This works because as of 91d7de4 we only store updates if they are new, instead of storing a new update every update interval regardless of whether there's a change. iTrak appears to only return new updates if the vehicle is not stationary.

Also changed the vehicle `active` flag to be `enabled`. This better reflects the intent for it to be admin-controlled instead of determined by the shuttle's own activity.