### PR TITLE
Dark mode persistence with localStorage

### DIFF
--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -451,6 +451,7 @@ Vue.component('dropdown-menu',{
 
         window.addEventListener('touchstart', function (event) {vm.dropdownWindowclick(event)});
         window.addEventListener('mousedown', function (event) {vm.dropdownWindowclick(event)});
+        window.addEventListener('load', function () {vm.loadDarkmode()});
 
     },
   data (){
@@ -492,6 +493,20 @@ Vue.component('dropdown-menu',{
                 if (this.darkmodeOn === 0) {
                     this.enableDarkmode();
                 } else {
+                    this.disableDarkmode();
+                }
+            }
+        },
+        loadDarkmode: function () {
+			// if localStorage is supported, read the value of darkmodeOn (if it exists),
+			// then enable/disable dark mode as needed
+            if (typeof(Storage) !== "undefined") {
+                if (localStorage.darkmodeOn === "0") {
+                    this.disableDarkmode();
+                } else if (localStorage.darkmodeOn === "1") {
+                    this.enableDarkmode();
+                } else {
+                    localStorage.darkmodeOn = 0;
                     this.disableDarkmode();
                 }
             }

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -498,8 +498,8 @@ Vue.component('dropdown-menu',{
             }
         },
         loadDarkmode: function () {
-			// if localStorage is supported, read the value of darkmodeOn (if it exists),
-			// then enable/disable dark mode as needed
+            // if localStorage is supported, read the value of darkmodeOn (if it exists),
+            // then enable/disable dark mode as needed
             if (typeof(Storage) !== "undefined") {
                 if (localStorage.darkmodeOn === "0") {
                     this.disableDarkmode();

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -523,8 +523,9 @@ Vue.component('dropdown-menu',{
             document.querySelector('div.leaflet-bottom.leaflet-right').style.filter = 'invert(1)';
             document.querySelector('div.titleBar').style.filter = 'invert(1)';
             // invert specific colors twice to make them normal
+            document.querySelector('ul#titleContent-right').style.filter = 'invert(1)';
+            document.querySelector('ul#titleContent-right>li>div').style.filter = 'invert(1)';
             document.querySelector('div.pulsate').style.filter = 'invert(1)';
-            document.querySelector('a.logo').style.filter = 'invert(1)';
             var leafletControlLinks = document.querySelectorAll('div.leaflet-control>a');
             for (var i = 0; i < leafletControlLinks.length; i++) {
                 leafletControlLinks[i].style.filter = 'invert(1)';
@@ -546,8 +547,9 @@ Vue.component('dropdown-menu',{
             document.querySelector('div.leaflet-bottom.leaflet-right').style.filter = 'invert(0)';
             document.querySelector('div.titleBar').style.filter = 'invert(0)';
             // reset specific colors to make normal
+            document.querySelector('ul#titleContent-right').style.filter = 'invert(0)';
+            document.querySelector('ul#titleContent-right>li>div').style.filter = 'invert(0)';
             document.querySelector('div.pulsate').style.filter = 'invert(0)';
-            document.querySelector('a.logo').style.filter = 'invert(0)';
             var leafletControlLinks = document.querySelectorAll('div.leaflet-control>a');
             for (var i = 0; i < leafletControlLinks.length; i++) {
                 leafletControlLinks[i].style.filter = 'invert(0)';

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -449,9 +449,9 @@ Vue.component('dropdown-menu',{
     mounted() {
         var vm = this;
 
-        window.addEventListener('touchstart', function (event) {vm.dropdownWindowclick(event)});
-        window.addEventListener('mousedown', function (event) {vm.dropdownWindowclick(event)});
-        window.addEventListener('load', function () {vm.loadDarkmode()});
+        window.addEventListener('touchstart', function (event) {vm.dropdownWindowclick(event);});
+        window.addEventListener('mousedown', function (event) {vm.dropdownWindowclick(event);});
+        window.addEventListener('load', function () {vm.loadDarkmode();});
 
     },
   data (){

--- a/static/js/frontend.js
+++ b/static/js/frontend.js
@@ -477,14 +477,31 @@ Vue.component('dropdown-menu',{
         // following functions involve changing the dark mode state
         toggleDarkmode: function () {
             // toggles dark mode for the map portion of the site by applying the 'filter: invert' property
-            if (this.darkmodeOn === 0) {
-                this.enableDarkmode();
+            // For browsers that implement localStorage, read/write the dark mode toggle from localStorage
+            // LocalStorage only stores keys and values as strings (Thanks JS!)
+            if (typeof(Storage) !== "undefined") {
+                if (localStorage.darkmodeOn === "0") {
+                    this.enableDarkmode();
+                } else if (localStorage.darkmodeOn === "1") {
+                    this.disableDarkmode();
+                } else {
+                    localStorage.darkmodeOn = 1;
+                    this.enableDarkmode();
+                }
             } else {
-                this.disableDarkmode();
+                if (this.darkmodeOn === 0) {
+                    this.enableDarkmode();
+                } else {
+                    this.disableDarkmode();
+                }
             }
         },
         enableDarkmode: function () {
-            this.darkmodeOn = 1;
+            if (typeof(Storage) !== "undefined") {
+                localStorage.darkmodeOn = 1;
+            } else {
+                this.darkmodeOn = 1;
+            }
             document.querySelector('div#darkmode-icon>img').src = this.sunicon;
             document.querySelector('div.leaflet-tile-pane').style.filter = 'invert(1)';
             document.querySelector('div.leaflet-bottom.leaflet-left').style.filter = 'invert(1)';
@@ -503,7 +520,11 @@ Vue.component('dropdown-menu',{
             }
         },
         disableDarkmode: function () {
-            this.darkmodeOn = 0;
+            if (typeof(Storage) !== "undefined") {
+                localStorage.darkmodeOn = 0;
+            } else {
+                this.darkmodeOn = 0;
+            }
             document.querySelector('div#darkmode-icon>img').src = this.moonicon;
             document.querySelector('div.leaflet-tile-pane').style.filter = 'invert(0)';
             document.querySelector('div.leaflet-bottom.leaflet-left').style.filter = 'invert(0)';


### PR DESCRIPTION
On browsers that support localStorage (i.e. most modern browsers), set/get the variable `darkmodeOn` for toggling dark mode. On page load, get the variable and set dark mode as necessary.

See issue #127 