### PR TITLE
Compress responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,14 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-# cache:
-#   directories:
-#     - $GOPATH/src
-#     - $GOPATH/pkg
+cache:
+  directories:
+    - $GOPATH/src
+    - $GOPATH/pkg
+
+before_cache:
+  - rm -rf $GOPATH/src/github.com/wtg/shuttletracker/*
+  - rm -rf $GOPATH/pkg/**/github.com/wtg/shuttletracker/*
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 
 go:
-  - "1.7.x"
-  - "1.8.x"
-  - "1.9.x"
-  - "1.10.x"
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - tip
 
 matrix:
@@ -22,6 +22,11 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+cache:
+  directories:
+    - $GOPATH/src
+    - $GOPATH/pkg
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ matrix:
   allow_failures:
     - go: tip
 
-before_install:
+install:
   - go get -u github.com/kardianos/govendor && govendor sync
   - go get -u github.com/alecthomas/gometalinter && gometalinter --install
+  - go get -u github.com/bradleyfalzon/revgrep/...
 
 script:
-  - gometalinter --vendor ./... || true
+  - gometalinter --vendor ./... 2>&1 | revgrep origin/master
   - ./test.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
   - go get -u github.com/bradleyfalzon/revgrep/...
 
 script:
-  - gometalinter --vendor ./... 2>&1 | revgrep origin/master
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then gometalinter --vendor ./... 2>&1 | revgrep origin/master; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then gometalinter --vendor ./... || true; fi
   - ./test.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-cache:
-  directories:
-    - $GOPATH/src
-    - $GOPATH/pkg
+# cache:
+#   directories:
+#     - $GOPATH/src
+#     - $GOPATH/pkg
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ matrix:
   allow_failures:
     - go: tip
 
-install:
+before_install:
   - go get -u github.com/kardianos/govendor && govendor sync
   - go get -u github.com/alecthomas/gometalinter && gometalinter --install
   - go get -u github.com/bradleyfalzon/revgrep/...
+
+install:
+  - go install
 
 script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then gometalinter --vendor ./... 2>&1 | revgrep origin/master; fi

--- a/api/api.go
+++ b/api/api.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
 	"github.com/spf13/viper"
 	"gopkg.in/cas.v1"
 
@@ -59,6 +60,7 @@ func New(cfg Config, db database.Database) (*API, error) {
 
 	r := chi.NewRouter()
 
+	r.Use(middleware.DefaultCompress)
 	r.Use(etag)
 
 	// Vehicles

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -34,7 +34,7 @@ func TestWriteJSON(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			data:          make(chan (int)),
+			data:          make(chan int),
 			expectedWrite: "",
 			expectedError: true,
 		},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,9 +2,70 @@ package api
 
 import (
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+
+	"github.com/wtg/shuttletracker/database"
 )
+
+func TestStatic(t *testing.T) {
+	type testCase struct {
+		method string
+		path   string
+	}
+	cases := []testCase{
+		{
+			method: "GET",
+			path:   "/",
+		},
+		{
+			method: "GET",
+			path:   "/static/css/application.css",
+		},
+		{
+			method: "GET",
+			path:   "/static/js/frontend.js",
+		},
+	}
+
+	// Go tests are run from the package dir, but our static files are one level higher
+	os.Chdir("..")
+
+	cfg := Config{}
+	db := &database.Mock{}
+
+	api, err := New(cfg, db)
+	if err != nil {
+		t.Errorf("got error '%s', expected nil", err)
+		return
+	}
+
+	server := httptest.NewServer(api.handler)
+	defer server.Close()
+	client := server.Client()
+
+	for _, c := range cases {
+		url := server.URL + c.path
+		req, err := http.NewRequest(c.method, url, nil)
+		if err != nil {
+			t.Errorf("unable to create HTTP request: %s", err)
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Errorf("unable to do request: %s", err)
+			continue
+		}
+
+		if resp.StatusCode != 200 {
+			t.Logf("%+v", req)
+			t.Logf("%+v", resp)
+			t.Errorf("%s %s returned status code %d, expected 200", c.method, url, resp.StatusCode)
+		}
+	}
+}
 
 func TestWriteJSON(t *testing.T) {
 	type testCase struct {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSON(t *testing.T) {
+	type testCase struct {
+		data          interface{}
+		expectedWrite string
+		expectedError bool
+	}
+	cases := []testCase{
+		{
+			data:          "hello there",
+			expectedWrite: `"hello there"`,
+			expectedError: false,
+		},
+		{
+			data: map[int][]string{
+				1: []string{
+					"hello",
+					"there",
+				},
+			},
+			expectedWrite: "{\n" +
+				" \"1\": [\n" +
+				"  \"hello\",\n" +
+				"  \"there\"\n" +
+				" ]\n" +
+				"}",
+			expectedError: false,
+		},
+		{
+			data:          make(chan (int)),
+			expectedWrite: "",
+			expectedError: true,
+		},
+	}
+
+	for _, c := range cases {
+		w := httptest.NewRecorder()
+		err := WriteJSON(w, c.data)
+
+		if err != nil && !c.expectedError {
+			t.Errorf("got error '%s', expected nil", err)
+			continue
+		} else if c.expectedError && err == nil {
+			t.Errorf("didn't get error, expected '%s'", err)
+			continue
+		} else if c.expectedError && err != nil {
+			continue
+		}
+
+		res := w.Result()
+		if res.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("got unexpected Content-Type '%s', expected 'application/json'", res.Header.Get("Content-Type"))
+		}
+
+		actualWrite, _ := ioutil.ReadAll(res.Body)
+		if string(actualWrite) != c.expectedWrite {
+			t.Errorf("got unexpected body '%s', expected '%s'", actualWrite, c.expectedWrite)
+		}
+	}
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -44,7 +44,7 @@ func TestStatic(t *testing.T) {
 
 	server := httptest.NewServer(api.handler)
 	defer server.Close()
-	client := server.Client()
+	client := http.Client{}
 
 	for _, c := range cases {
 		url := server.URL + c.path

--- a/api/etag_test.go
+++ b/api/etag_test.go
@@ -23,13 +23,13 @@ func TestETag(t *testing.T) {
 		body       string
 	}
 	cases := []testCase{
-		testCase{
+		{
 			clientETag: "",
 			serverETag: "6e71b3cac15d32fe2d36c270887df9479c25c640",
 			statusCode: 200,
 			body:       "hello there",
 		},
-		testCase{
+		{
 			clientETag: "6e71b3cac15d32fe2d36c270887df9479c25c640",
 			serverETag: "6e71b3cac15d32fe2d36c270887df9479c25c640",
 			statusCode: 304,

--- a/database/mock.go
+++ b/database/mock.go
@@ -1,0 +1,127 @@
+package database
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/wtg/shuttletracker/model"
+)
+
+type Mock struct {
+	mock.Mock
+}
+
+func (db *Mock) CreateRoute(route *model.Route) error {
+	args := db.Called(route)
+	return args.Error(0)
+}
+
+func (db *Mock) DeleteRoute(routeID string) error {
+	args := db.Called(routeID)
+	return args.Error(0)
+}
+
+func (db *Mock) GetRoute(routeID string) (model.Route, error) {
+	args := db.Called(routeID)
+	return args.Get(0).(model.Route), args.Error(1)
+}
+
+func (db *Mock) GetRoutes() ([]model.Route, error) {
+	args := db.Called()
+	return args.Get(0).([]model.Route), args.Error(1)
+}
+
+func (db *Mock) ModifyRoute(route *model.Route) error {
+	args := db.Called(route)
+	return args.Error(0)
+}
+
+func (db *Mock) CreateStop(stop *model.Stop) error {
+	args := db.Called(stop)
+	return args.Error(0)
+}
+
+func (db *Mock) DeleteStop(stopID string) error {
+	args := db.Called(stopID)
+	return args.Error(0)
+}
+
+func (db *Mock) GetStops() ([]model.Stop, error) {
+	args := db.Called()
+	return args.Get(0).([]model.Stop), args.Error(1)
+}
+
+func (db *Mock) CreateVehicle(vehicle *model.Vehicle) error {
+	args := db.Called(vehicle)
+	return args.Error(0)
+}
+
+func (db *Mock) DeleteVehicle(vehicleID string) error {
+	args := db.Called(vehicleID)
+	return args.Error(0)
+}
+
+func (db *Mock) GetVehicle(vehicleID string) (model.Vehicle, error) {
+	args := db.Called(vehicleID)
+	return args.Get(0).(model.Vehicle), args.Error(1)
+}
+
+func (db *Mock) GetVehicles() ([]model.Vehicle, error) {
+	args := db.Called()
+	return args.Get(0).([]model.Vehicle), args.Error(1)
+}
+
+func (db *Mock) GetEnabledVehicles() ([]model.Vehicle, error) {
+	args := db.Called()
+	return args.Get(0).([]model.Vehicle), args.Error(1)
+}
+
+func (db *Mock) ModifyVehicle(vehicle *model.Vehicle) error {
+	args := db.Called(vehicle)
+	return args.Error(0)
+}
+
+func (db *Mock) CreateUpdate(update *model.VehicleUpdate) error {
+	args := db.Called(update)
+	return args.Error(0)
+}
+
+func (db *Mock) DeleteUpdatesBefore(before time.Time) (int, error) {
+	args := db.Called(before)
+	return args.Int(0), args.Error(1)
+}
+
+func (db *Mock) GetUpdatesForVehicleSince(vehicleID string, since time.Time) ([]model.VehicleUpdate, error) {
+	args := db.Called(vehicleID, since)
+	return args.Get(0).([]model.VehicleUpdate), args.Error(1)
+}
+
+func (db *Mock) GetLastUpdateForVehicle(vehicleID string) (model.VehicleUpdate, error) {
+	args := db.Called(vehicleID)
+	return args.Get(0).(model.VehicleUpdate), args.Error(1)
+}
+
+func (db *Mock) GetUsers() ([]model.User, error) {
+	args := db.Called()
+	return args.Get(0).([]model.User), args.Error(1)
+}
+
+func (db *Mock) AddMessage(message *model.AdminMessage) error {
+	args := db.Called(message)
+	return args.Error(0)
+}
+
+func (db *Mock) GetCurrentMessage() (model.AdminMessage, error) {
+	args := db.Called()
+	return args.Get(0).(model.AdminMessage), args.Error(1)
+}
+
+func (db *Mock) GetMessages() ([]model.AdminMessage, error) {
+	args := db.Called()
+	return args.Get(0).([]model.AdminMessage), args.Error(1)
+}
+
+func (db *Mock) ClearMessage() error {
+	args := db.Called()
+	return args.Error(0)
+}

--- a/database/mock.go
+++ b/database/mock.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+
 	"github.com/wtg/shuttletracker/model"
 )
 

--- a/database/mock.go
+++ b/database/mock.go
@@ -7,120 +7,144 @@ import (
 	"github.com/wtg/shuttletracker/model"
 )
 
+// Mock implements the database interface. Great for tests.
 type Mock struct {
 	mock.Mock
 }
 
+// CreateRoute creates a route.
 func (db *Mock) CreateRoute(route *model.Route) error {
 	args := db.Called(route)
 	return args.Error(0)
 }
 
+// DeleteRoute deletes a route.
 func (db *Mock) DeleteRoute(routeID string) error {
 	args := db.Called(routeID)
 	return args.Error(0)
 }
 
+// GetRoute gets a route.
 func (db *Mock) GetRoute(routeID string) (model.Route, error) {
 	args := db.Called(routeID)
 	return args.Get(0).(model.Route), args.Error(1)
 }
 
+// GetRoutes gets all routes.
 func (db *Mock) GetRoutes() ([]model.Route, error) {
 	args := db.Called()
 	return args.Get(0).([]model.Route), args.Error(1)
 }
 
+// ModifyRoute modifies a route.
 func (db *Mock) ModifyRoute(route *model.Route) error {
 	args := db.Called(route)
 	return args.Error(0)
 }
 
+// CreateStop creates a stop.
 func (db *Mock) CreateStop(stop *model.Stop) error {
 	args := db.Called(stop)
 	return args.Error(0)
 }
 
+// DeleteStop deletes a stop.
 func (db *Mock) DeleteStop(stopID string) error {
 	args := db.Called(stopID)
 	return args.Error(0)
 }
 
+// GetStops gets all stops.
 func (db *Mock) GetStops() ([]model.Stop, error) {
 	args := db.Called()
 	return args.Get(0).([]model.Stop), args.Error(1)
 }
 
+// CreateVehicle creates a vehicle.
 func (db *Mock) CreateVehicle(vehicle *model.Vehicle) error {
 	args := db.Called(vehicle)
 	return args.Error(0)
 }
 
+// DeleteVehicle deletes a vehicle.
 func (db *Mock) DeleteVehicle(vehicleID string) error {
 	args := db.Called(vehicleID)
 	return args.Error(0)
 }
 
+// GetVehicle gets a vehicle.
 func (db *Mock) GetVehicle(vehicleID string) (model.Vehicle, error) {
 	args := db.Called(vehicleID)
 	return args.Get(0).(model.Vehicle), args.Error(1)
 }
 
+// GetVehicles gets all vehicles.
 func (db *Mock) GetVehicles() ([]model.Vehicle, error) {
 	args := db.Called()
 	return args.Get(0).([]model.Vehicle), args.Error(1)
 }
 
+// GetEnabledVehicles gets all enabled vehicles.
 func (db *Mock) GetEnabledVehicles() ([]model.Vehicle, error) {
 	args := db.Called()
 	return args.Get(0).([]model.Vehicle), args.Error(1)
 }
 
+// ModifyVehicle modifies a vehicle.
 func (db *Mock) ModifyVehicle(vehicle *model.Vehicle) error {
 	args := db.Called(vehicle)
 	return args.Error(0)
 }
 
+// CreateUpdate creates an update.
 func (db *Mock) CreateUpdate(update *model.VehicleUpdate) error {
 	args := db.Called(update)
 	return args.Error(0)
 }
 
+// DeleteUpdatesBefore deletes all updates before a time.
 func (db *Mock) DeleteUpdatesBefore(before time.Time) (int, error) {
 	args := db.Called(before)
 	return args.Int(0), args.Error(1)
 }
 
+// GetUpdatesForVehicleSince gets all updates for a vehicle since a time.
 func (db *Mock) GetUpdatesForVehicleSince(vehicleID string, since time.Time) ([]model.VehicleUpdate, error) {
 	args := db.Called(vehicleID, since)
 	return args.Get(0).([]model.VehicleUpdate), args.Error(1)
 }
 
+// GetLastUpdateForVehicle gets the most recent update for a vehicle.
 func (db *Mock) GetLastUpdateForVehicle(vehicleID string) (model.VehicleUpdate, error) {
 	args := db.Called(vehicleID)
 	return args.Get(0).(model.VehicleUpdate), args.Error(1)
 }
 
+// GetUsers gets all users.
 func (db *Mock) GetUsers() ([]model.User, error) {
 	args := db.Called()
 	return args.Get(0).([]model.User), args.Error(1)
 }
 
+// AddMessage adds a message.
 func (db *Mock) AddMessage(message *model.AdminMessage) error {
 	args := db.Called(message)
 	return args.Error(0)
 }
 
+// GetCurrentMessage gets the current message.
 func (db *Mock) GetCurrentMessage() (model.AdminMessage, error) {
 	args := db.Called()
 	return args.Get(0).(model.AdminMessage), args.Error(1)
 }
 
+// GetMessages gets all messages.
 func (db *Mock) GetMessages() ([]model.AdminMessage, error) {
 	args := db.Called()
 	return args.Get(0).([]model.AdminMessage), args.Error(1)
 }
 
+// ClearMessage clears the message.
 func (db *Mock) ClearMessage() error {
 	args := db.Called()
 	return args.Error(0)

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -e
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
+    go test -v -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -13,6 +13,12 @@
 			"revisionTime": "2015-12-04T14:14:43Z"
 		},
 		{
+			"checksumSHA1": "CSPbwbyzqA6sfORicn4HFtIhF/c=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "8991bc29aa16c548c550c7ff78260e27b9ab7c73",
+			"revisionTime": "2018-02-21T22:46:20Z"
+		},
+		{
 			"checksumSHA1": "x2Km0Qy3WgJJnV19Zv25VwTJcBM=",
 			"path": "github.com/fsnotify/fsnotify",
 			"revision": "4da3e2cfbabc9f751898f250b49f2439785783a1",
@@ -127,6 +133,12 @@
 			"revisionTime": "2017-06-28T01:26:37Z"
 		},
 		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
 			"checksumSHA1": "lBehULzb2/kIK3wZ0gz2yNmHq9s=",
 			"path": "github.com/spf13/afero",
 			"revision": "9be650865eab0c12963d8753212f4f9c66cdcf12",
@@ -161,6 +173,24 @@
 			"path": "github.com/spf13/viper",
 			"revision": "25b30aa063fc18e48662b86996252eabdcf2f0c7",
 			"revisionTime": "2017-07-23T05:52:07Z"
+		},
+		{
+			"checksumSHA1": "6thzskcj6XrMO5kW6GlRiuTDYjU=",
+			"path": "github.com/stretchr/objx",
+			"revision": "8a3f7159479fbc75b30357fbc48f380b7320f08e",
+			"revisionTime": "2018-01-29T17:20:03Z"
+		},
+		{
+			"checksumSHA1": "6LwXZI7kXm1C0h4Ui0Y52p9uQhk=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "Qloi2PTvZv+D9FDHXM/banCoaFY=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
 		},
 		{
 			"checksumSHA1": "Sypcm+UJjiKcT7P7kSp87nVuDtI=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -25,6 +25,12 @@
 			"revisionTime": "2018-02-02T19:41:35Z"
 		},
 		{
+			"checksumSHA1": "1Xlo4sCR+zeOzjslXc/NAOmkgXg=",
+			"path": "github.com/go-chi/chi/middleware",
+			"revision": "e223a795a06a5598451cf022558c17c779f5a7ab",
+			"revisionTime": "2018-02-02T19:41:35Z"
+		},
+		{
 			"checksumSHA1": "42vkdsxNaLyPu+FktCzZ/8zsNSE=",
 			"path": "github.com/go-sql-driver/mysql",
 			"revision": "9dee4ca50b83acdf57a35fb9e6fb4be640afa2f3",


### PR DESCRIPTION
Compress all responses with gzip. This ensures that the Union's reverse proxy won't attempt to compress our responses and strip our ETag headers.