### PR TITLE
Fix modal in Firefox

### DIFF
--- a/static/css/application.css
+++ b/static/css/application.css
@@ -2,8 +2,8 @@ html, body {
   background-color: #f7f7f7;
   height: 100%;
   width: 100%;
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
@@ -125,19 +125,17 @@ li {
 div.modal{
   position: fixed;
   z-index: 10;
-  padding: 50px 0 30px;
   top: 0;
-  bottom: 0;
   left: 0;
   right: 0;
   overflow: auto;
-  background-color: rgb(0,0,0);
   background-color: rgba(0,0,0,0.4);
+  height: 100vh;
 }
 
 div.modalContent{
   background-color: #fefefe;
-  margin: auto;
+  margin: 50px auto 30px;
   z-index: 10;
   padding: 20px;
   border: 1px solid #888;


### PR DESCRIPTION
Resolves #139. Firefox doesn't like when a `position: fixed` element has top and bottom position properties, so I set only top and then the height to the viewport height.