### PR TITLE
iTRAK data feed endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -122,7 +122,7 @@ func New(cfg Config, ms shuttletracker.ModelService, msg shuttletracker.MessageS
 	r.Get("/", IndexHandler)
 	r.Method("GET", "/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir("static/"))))
 
-	// iTrak data feed endpoint
+	// iTRAK data feed endpoint
 	r.Get("/datafeed", api.DataFeedHandler)
 
 	api.handler = r

--- a/api/api.go
+++ b/api/api.go
@@ -119,6 +119,9 @@ func New(cfg Config, ms shuttletracker.ModelService, msg shuttletracker.MessageS
 	r.Get("/", IndexHandler)
 	r.Method("GET", "/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir("static/"))))
 
+	// iTrak data feed endpoint
+	r.Get("/datafeed", api.DataFeedHandler)
+
 	api.handler = r
 
 	return &api, nil

--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/wtg/shuttletracker"
 	"github.com/wtg/shuttletracker/log"
+	"github.com/wtg/shuttletracker/updater"
 )
 
 // Config holds API settings.
@@ -30,11 +31,12 @@ type API struct {
 	handler http.Handler
 	ms      shuttletracker.ModelService
 	msg     shuttletracker.MessageService
+	updater *updater.Updater
 }
 
 // New initializes the application given a config and connects to backends.
 // It also seeds any needed information to the database.
-func New(cfg Config, ms shuttletracker.ModelService, msg shuttletracker.MessageService, us shuttletracker.UserService) (*API, error) {
+func New(cfg Config, ms shuttletracker.ModelService, msg shuttletracker.MessageService, us shuttletracker.UserService, updater *updater.Updater) (*API, error) {
 	// Set up CAS authentication
 	url, err := url.Parse(cfg.CasURL)
 	if err != nil {
@@ -43,9 +45,10 @@ func New(cfg Config, ms shuttletracker.ModelService, msg shuttletracker.MessageS
 
 	// Create API instance to store database session and collections
 	api := API{
-		cfg: cfg,
-		ms:  ms,
-		msg: msg,
+		cfg:     cfg,
+		ms:      ms,
+		msg:     msg,
+		updater: updater,
 	}
 
 	r := chi.NewRouter()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -38,7 +38,7 @@ func TestStatic(t *testing.T) {
 	msg := &mock.MessageService{}
 	us := &mock.UserService{}
 
-	api, err := New(cfg, ms, msg, us)
+	api, err := New(cfg, ms, msg, us, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 		return

--- a/api/data_feed.go
+++ b/api/data_feed.go
@@ -1,6 +1,14 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+)
 
 func (api *API) DataFeedHandler(w http.ResponseWriter, r *http.Request) {
+	dfresp := api.updater.GetLastResponse()
+	if dfresp == nil {
+		http.Error(w, "Last data feed response does not exist", http.StatusNotFound)
+		return
+	}
+	w.Write(dfresp.Body)
 }

--- a/api/data_feed.go
+++ b/api/data_feed.go
@@ -1,0 +1,6 @@
+package api
+
+import "net/http"
+
+func (api *API) DataFeedHandler(w http.ResponseWriter, r *http.Request) {
+}

--- a/cmd/shuttletracker/main.go
+++ b/cmd/shuttletracker/main.go
@@ -57,7 +57,7 @@ func Run() {
 	runner.Add(updater)
 
 	// Make API server
-	api, err := api.New(*cfg.API, ms, msg, us)
+	api, err := api.New(*cfg.API, ms, msg, us, updater)
 	if err != nil {
 		log.WithError(err).Error("Could not create API server.")
 		return


### PR DESCRIPTION
This provides an API endpoint on shuttles.rpi.edu that simply passes through the data from iTRAK. Eventually, newly-installed Shuttle Tracker instances could query it by default if they are not configured with the iTRAK data feed URL, so we won't have to distribute it to team members.