### PR TITLE
Set datafeed endpoint content type

### DIFF
--- a/api/data_feed.go
+++ b/api/data_feed.go
@@ -14,6 +14,7 @@ func (api *API) DataFeedHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Last data feed response does not exist", http.StatusNotFound)
 		return
 	}
+	w.Header().Set("Content-Type", "text/plain")
 	_, err := w.Write(dfresp.Body)
 	if err != nil {
 		log.WithError(err).Error("unable to write")


### PR DESCRIPTION
The `/datafeed` endpoint will now always return a header `Content-Type: text/plain` when writing untrusted content. Fixes a potential security issue. Resolves #161.