### PR TITLE
Do not allow static directory listings

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -120,7 +120,7 @@ func New(cfg Config, ms shuttletracker.ModelService, msg shuttletracker.MessageS
 
 	// Static files
 	r.Get("/", IndexHandler)
-	r.Method("GET", "/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir("static/"))))
+	r.Method("GET", "/static/*", http.StripPrefix("/static/", http.FileServer(staticFileSystem{http.Dir("static/")})))
 
 	// iTRAK data feed endpoint
 	r.Get("/datafeed", api.DataFeedHandler)

--- a/api/filesystem.go
+++ b/api/filesystem.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"net/http"
+	"os"
+)
+
+type staticFileSystem struct {
+	fs http.FileSystem
+}
+
+// Open will only return Files that are not directories.
+func (sfs staticFileSystem) Open(path string) (http.File, error) {
+	f, err := sfs.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if s.IsDir() {
+		return nil, os.ErrNotExist
+	}
+
+	return f, nil
+}


### PR DESCRIPTION
Create a custom filesystem type that returns `os.ErrNotExist` for any directories. This prevents `http.FileServer` from returning static directory listings (e.g. https://shuttles.rpi.edu/static/ will now return 404).

Resolves #156.