### PR TITLE
Route scheduling, part two: electric boogaloo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,3 @@ cache:
 before_cache:
   - rm -rf $GOPATH/src/github.com/wtg/shuttletracker/*
   - rm -rf $GOPATH/pkg/**/github.com/wtg/shuttletracker/*
-
-notifications:
-  email: false

--- a/api/routes.go
+++ b/api/routes.go
@@ -76,8 +76,10 @@ func (api *API) RoutesEditHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	en := route.Enabled
+	sched := route.Schedule
 	route, err = api.ms.Route(route.ID)
 	route.Enabled = en
+	route.Schedule = sched
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/postgres/route.go
+++ b/postgres/route.go
@@ -162,7 +162,7 @@ GROUP BY r.id;
 	for rows.Next() {
 		r := &shuttletracker.Route{}
 		p := scanPoints{}
-		err := rows.Scan(&r.ID, &r.Name, &r.Created, &r.Updated, &r.Enabled, &r.Width, &r.Color, &p, pq.Array(&r.StopIDs), &r.Active)
+		err = rows.Scan(&r.ID, &r.Name, &r.Created, &r.Updated, &r.Enabled, &r.Width, &r.Color, &p, pq.Array(&r.StopIDs), &r.Active)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +179,7 @@ GROUP BY r.id;
 	}
 	for rows.Next() {
 		interval := shuttletracker.RouteActiveInterval{}
-		err := rows.Scan(&interval.ID, &interval.RouteID, &interval.StartDay, &interval.StartTime, &interval.EndDay, &interval.EndTime)
+		err = rows.Scan(&interval.ID, &interval.RouteID, &interval.StartDay, &interval.StartTime, &interval.EndDay, &interval.EndTime)
 		if err != nil {
 			return nil, err
 		}
@@ -234,7 +234,7 @@ func (rs *RouteService) Route(id int64) (*shuttletracker.Route, error) {
 		interval := shuttletracker.RouteActiveInterval{
 			RouteID: id,
 		}
-		err := rows.Scan(&interval.ID, &interval.StartDay, &interval.StartTime, &interval.EndDay, &interval.EndTime)
+		err = rows.Scan(&interval.ID, &interval.StartDay, &interval.StartTime, &interval.EndDay, &interval.EndTime)
 		if err != nil {
 			return nil, err
 		}

--- a/postgres/route.go
+++ b/postgres/route.go
@@ -307,6 +307,18 @@ func (rs *RouteService) CreateRoute(route *shuttletracker.Route) error {
 		return err
 	}
 
+	// insert route schedule
+	for _, interval := range route.Schedule {
+		statement = "INSERT INTO route_schedules (route_id, start_day, start_time, end_day, end_time)" +
+			" VALUES ($1, $2, $3, $4, $5) RETURNING id;"
+		row := tx.QueryRow(statement, route.ID, interval.StartDay, interval.StartTime, interval.EndDay, interval.EndTime)
+		err = row.Scan(&interval.ID)
+		if err != nil {
+			return err
+		}
+		interval.RouteID = route.ID
+	}
+
 	return tx.Commit()
 }
 

--- a/postgres/route.go
+++ b/postgres/route.go
@@ -80,7 +80,7 @@ CREATE OR REPLACE FUNCTION route_is_active(route_id integer) RETURNS boolean STA
 			route_schedules.route_id = route_is_active.route_id
 			AND route_schedules.id = timestamps.id
 			AND now() >= timestamps.start
-			AND now() < timestamps.end
+			AND now() <= timestamps.end
 			OR (
 				NOT EXISTS (
 					SELECT 1 from route_schedules

--- a/postgres/route.go
+++ b/postgres/route.go
@@ -47,7 +47,10 @@ CREATE TABLE IF NOT EXISTS route_schedules (
 	start_day smallint NOT NULL CHECK (start_day >= 0 AND start_day <= 7),
 	start_time time with time zone NOT NULL,
 	end_day smallint NOT NULL CHECK (end_day >= 0 AND end_day <= 7),
-	end_time time with time zone NOT NULL
+	end_time time with time zone NOT NULL,
+	CHECK (
+		(start_day = end_day AND start_time < end_time) OR (start_day < end_day)
+	)
 );
 CREATE OR REPLACE FUNCTION route_is_active(route_id integer) RETURNS boolean STABLE AS $$
 	SELECT exists(

--- a/route.go
+++ b/route.go
@@ -17,7 +17,22 @@ type Route struct {
 	Created     time.Time `json:"created"`
 	Updated     time.Time `json:"updated"`
 	Points      []Point   `json:"points"`
+	// Schedule    RouteSchedule `json:"schedule"`
+	Active bool `json:"active"`
 }
+
+// RouteActiveInterval represents a time interval during which a Route is active.
+type RouteActiveInterval struct {
+	ID        int64        `json:"id"`
+	RouteID   int64        `json:"route_id"`
+	StartDay  time.Weekday `json:"start_day"`
+	StartTime time.Time    `json:"start_time"`
+	EndDay    time.Weekday `json:"end_day"`
+	EndTime   time.Time    `json:"end_time"`
+}
+
+// RouteSchedule represents multiple time intervals during which a Route is active.
+type RouteSchedule []RouteActiveInterval
 
 // Point represents a latitude/longitude pair.
 type Point struct {

--- a/route.go
+++ b/route.go
@@ -7,18 +7,18 @@ import (
 
 // Route represents a set of coordinates to draw a path on our tracking map
 type Route struct {
-	ID          int64     `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Enabled     bool      `json:"enabled"`
-	Color       string    `json:"color"`
-	Width       int64     `json:"width"`
-	StopIDs     []int64   `json:"stop_ids"`
-	Created     time.Time `json:"created"`
-	Updated     time.Time `json:"updated"`
-	Points      []Point   `json:"points"`
-	// Schedule    RouteSchedule `json:"schedule"`
-	Active bool `json:"active"`
+	ID          int64         `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Enabled     bool          `json:"enabled"`
+	Color       string        `json:"color"`
+	Width       int64         `json:"width"`
+	StopIDs     []int64       `json:"stop_ids"`
+	Created     time.Time     `json:"created"`
+	Updated     time.Time     `json:"updated"`
+	Points      []Point       `json:"points"`
+	Active      bool          `json:"active"`
+	Schedule    RouteSchedule `json:"schedule"`
 }
 
 // RouteActiveInterval represents a time interval during which a Route is active.

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -263,7 +263,7 @@ func (u *Updater) GuessRouteForVehicle(vehicle *shuttletracker.Vehicle) (route *
 
 	for _, update := range updates {
 		for _, route := range routes {
-			if !route.Enabled {
+			if !route.Enabled || !route.Active {
 				routeDistances[route.ID] += math.Inf(0)
 			}
 			nearestDistance := math.Inf(0)


### PR DESCRIPTION
So, here's the situation. There are routes, like the Weekend/Late Night route, that are only active on certain days and between certain hours. What's a Tracker to do? Log into the admin interface and manually flip the switch to turn it on or off? Well, yes, but that was before this pull request...

**Enter route scheduling**—a way to control when routes should show up on the map automatically.

## What is a schedule?

Each schedule is represented as a list of intervals during which the route should be active.
Active intervals consist of:

- Start day of week (0–6, where 0 is Sunday and 6 is Saturday)
- Start time
- End day of week (0–6)
- End time

### Interval start and end time invariant

Each interval's start day and start time must be before end day and end time, i.e.,
`(start_day = end_day AND start_time < end_time) OR (start_day < end_day)`.
This is to make my life easier inside `route_is_active()`. It is enforced by a constraint at the database level.

This means that to wrap a schedule around a week boundary, i.e. Saturday into Sunday, a schedule
would consist of two active intervals:
- Saturday, 8–11:59:59 pm
- Sunday, 12–4 am

### Routes without schedules

Routes without schedules are always considered active. Of course, they can always be manually togggled with the `Enabled` flag.

## Changes to `shuttletracker.Route`

`Route` has two new fields: `Schedule` and `Active`.

### `Enabled` vs. `Active`

`Enabled` is a way for an administrator to manually indicate that a route may show up on the map
(if true) or prevent it from ever showing up (if false).

`Active` is computed by the database based on the schedule associated with a route. It is true
if there is no schedule or if the current time is within one of the schedule's active intervals.
It is false otherwise.

A correct implementation of the map would only show routes whose `Enabled` and `Active`
fields are both true.

---
Resolves #154.
