### PR TITLE
Fix vehicle rotation and last update times

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -815,6 +815,14 @@
         "@types/geojson": "*"
       }
     },
+    "@types/leaflet-rotatedmarker": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.1.tgz",
+      "integrity": "sha512-JxHrRjLZBV4E+eLuj1c79pRR5pPBcQGWXypeTMxQLxNUcxlGuznetf7iXGJUvIX72CCFIZICIn9APEye2fPBkg==",
+      "requires": {
+        "@types/leaflet": "*"
+      }
+    },
     "@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@types/leaflet": "^1.2.10",
+    "@types/leaflet-rotatedmarker": "^0.2.1",
     "leaflet": "^1.3.4",
     "leaflet-rotatedmarker": "^0.2.0",
     "vue": "^2.5.17",

--- a/frontend/src/components/Public.vue
+++ b/frontend/src/components/Public.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
         let legendstring = '';
         this.$store.state.Routes.forEach((route: Route) => {
           if (route.enabled) {
-            legendstring += `<li><img class="legend-icon" src=` + getMarkerString(route.color, 0) + `
+            legendstring += `<li><img class="legend-icon" src=` + getMarkerString(route.color) + `
 			      width="12" height="12"> ` +
             route.name;
           }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -45,7 +45,7 @@ const store: StoreOptions<StoreState> = {
         let found = false;
         for (let i = 0; i < updates.length; i++) {
           if (Number(vehicle.id) === Number(updates[i].vehicle_id)) {
-            vehicle.lastUpdate = new Date(updates[i].date) ;
+            vehicle.lastUpdate = new Date(updates[i].time);
             found = true;
             vehicle.speed = Number(updates[i].speed);
             vehicle.setRoute(undefined);

--- a/frontend/src/structures/leaflet/rotatedMarker.ts
+++ b/frontend/src/structures/leaflet/rotatedMarker.ts
@@ -1,5 +1,5 @@
 const icon: string = `<?xml version="1.0" encoding="UTF-8"?>
-<svg transform="rotate(HEADING)" width="60px" height="60px" viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="60px" height="60px" viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>shuttle</title>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -10,6 +10,6 @@ const icon: string = `<?xml version="1.0" encoding="UTF-8"?>
     </g>
 </svg>`;
 
-export default function getMarkerString(color: string, angle: number) {
-    return 'data:image/svg+xml;base64,' + btoa(icon.replace('#33A7FF', color).replace('HEADING', String(angle)));
+export default function getMarkerString(color: string) {
+    return 'data:image/svg+xml;base64,' + btoa(icon.replace('#33A7FF', color));
 }

--- a/frontend/src/structures/update.ts
+++ b/frontend/src/structures/update.ts
@@ -6,10 +6,8 @@ export default interface Update {
     heading: number;
     speed: number;
     time: string;
-    date: string;
     status: string;
     created: string;
     route_id: number | null;
     vehicle_id: number;
-
 }


### PR DESCRIPTION
- Use leaflet-rotatedmarker to rotate markers instead of transforming the SVGs. The SVG transformation wasn't working properly in Safari.
- Use the timestamp from the most recent update in the vehicle's message. Previously it was the vehicle's creation time.