### PR TITLE
Fix user icon on map

### DIFF
--- a/frontend/src/components/Public.vue
+++ b/frontend/src/components/Public.vue
@@ -208,7 +208,7 @@ export default Vue.extend({
     },
     showUserLocation() {
       const userIcon = L.icon({
-        iconUrl: 'static/images/user.svg',
+        iconUrl: UserSVG,
 
         iconSize: [12, 12], // size of the icon
         iconAnchor: [6, 6], // point of the icon which will correspond to marker's location


### PR DESCRIPTION
The icon wasn't showing up on the map. Now we use its webpack loader import instead of a static URL (which was not valid).