### PR TITLE
Fix Fusion deadlock

### DIFF
--- a/api/fusion.go
+++ b/api/fusion.go
@@ -118,7 +118,7 @@ func newFusionManager(etaManager shuttletracker.ETAService) *fusionManager {
 		addClient:          make(chan *fusionClient),
 		removeClient:       make(chan string),
 		clientMsg:          make(chan clientMessage),
-		serverMsg:          make(chan serverMessage, 100),
+		serverMsg:          make(chan serverMessage, 100), // buffer needs to be at least as large as the number of messages that will be sent in any given loop through fusionManager's run() method
 		debug:              make(chan chan *fusionManagerDebug),
 		clients:            map[string]*fusionClient{},
 		tracks:             map[string][]fusionPosition{},

--- a/api/fusion.go
+++ b/api/fusion.go
@@ -118,7 +118,7 @@ func newFusionManager(etaManager shuttletracker.ETAService) *fusionManager {
 		addClient:          make(chan *fusionClient),
 		removeClient:       make(chan string),
 		clientMsg:          make(chan clientMessage),
-		serverMsg:          make(chan serverMessage, 50),
+		serverMsg:          make(chan serverMessage, 1000),
 		debug:              make(chan chan *fusionManagerDebug),
 		clients:            map[string]*fusionClient{},
 		tracks:             map[string][]fusionPosition{},

--- a/api/fusion.go
+++ b/api/fusion.go
@@ -118,7 +118,7 @@ func newFusionManager(etaManager shuttletracker.ETAService) *fusionManager {
 		addClient:          make(chan *fusionClient),
 		removeClient:       make(chan string),
 		clientMsg:          make(chan clientMessage),
-		serverMsg:          make(chan serverMessage, 15),
+		serverMsg:          make(chan serverMessage, 100),
 		debug:              make(chan chan *fusionManagerDebug),
 		clients:            map[string]*fusionClient{},
 		tracks:             map[string][]fusionPosition{},


### PR DESCRIPTION
The Fusion manager was deadlocking when a large number of clients connected at the same time.

The server message sending channel would fill up inside of the ETA subscribe handler and the handler would never complete because it would block on sending to the channel. Since it is running in the same goroutine as the WebSocket writer, the channel would never get drained and Fusion manager would get stuck.

This is now fixed by prioritizing sending messages out before handling any other channels. I also bumped the buffer size up a bit. It just needs to be at least as large as the number of messages that will be sent in any given loop through Fusion manager's `run()` method.