### PR TITLE
Links in admin messages

### DIFF
--- a/frontend/src/components/admin/MessagesAdmin.vue
+++ b/frontend/src/components/admin/MessagesAdmin.vue
@@ -7,6 +7,7 @@
                     <input v-model="newMessage" class="input" type="text" placeholder="Message Contents"/>
                     <p v-if="newMessage.length > 251" class="help is-danger">Message must be shorter than 251 characters.</p>
                     <input v-model="newLink" class="input" type="text" placeholder="Optional Link (Should Begin With http:// or https://)"/>
+                    <p v-if="newLink.length > 1 && newMessage.length < 1" class="help is-danger">Message must be set to add URL.</p>
                 </div>
                 <!-- <div class="control">
                     <button class="button is-info">Set Message</button>

--- a/frontend/src/components/admin/MessagesAdmin.vue
+++ b/frontend/src/components/admin/MessagesAdmin.vue
@@ -4,8 +4,9 @@
         <div style="margin-top: 15px; margin-bottom: 15px;">
             <div class="field has-addons">
                 <div class="control">
-                    <input v-model="newMessage" class="input" type="text"/>
+                    <input v-model="newMessage" class="input" type="text" placeholder="Message Contents"/>
                     <p v-if="newMessage.length > 251" class="help is-danger">Message must be shorter than 251 characters.</p>
+                    <input v-model="newLink" class="input" type="text" placeholder="Optional Link (Should Begin With http:// or https://)"/>
                 </div>
                 <!-- <div class="control">
                     <button class="button is-info">Set Message</button>
@@ -51,6 +52,8 @@ export default Vue.extend({
             newMessageVisible: false,
             fail: false,
             success: false,
+            currentLink: '',
+            newLink: '',
         }as {
             currentMessage: string;
             currentMessageVisible: boolean;
@@ -58,6 +61,8 @@ export default Vue.extend({
             newMessageVisible: boolean;
             fail: boolean;
             success: boolean;
+            currentLink: string;
+            newLink: string;
         };
     },
     mounted() {
@@ -65,7 +70,7 @@ export default Vue.extend({
     },
     methods: {
         save() {
-            const myMessage = new AdminMessageUpdate(this.newMessage, this.newMessageVisible, new Date(), new Date());
+            const myMessage = new AdminMessageUpdate(this.newMessage, this.newMessageVisible, new Date(), new Date(), this.newLink);
             AdminServiceProvider.SetMessage(myMessage).then((resp) => {
                 if (resp.ok) {
                     this.success = true;
@@ -92,6 +97,8 @@ export default Vue.extend({
                 this.currentMessageVisible = message.enabled;
                 this.newMessage = message.message;
                 this.newMessageVisible = message.enabled;
+                this.currentLink = message.link;
+                this.newLink = message.link;
             });
         },
     },

--- a/frontend/src/components/adminmessage.vue
+++ b/frontend/src/components/adminmessage.vue
@@ -1,7 +1,8 @@
 <template>
 <span>
     <div v-if="(this.message !== undefined && this.message.enabled === true) && !hide" id="messagebox">
-        <div style="width: 100%;float:left;" v-html="this.message.message"></div>
+        <div v-if="this.message.link === ''" style="width: 100%;float:left;" v-html="this.message.message"></div>
+        <a v-if="this.message.link !== ''" style="width: 100%;float:left;" v-html="this.message.message" v-bind:href="this.message.link" id="messageLink"></a>
         <div @click="hide = !hide" style="cursor: pointer;position:absolute;right:10px;top:6px;color:#333;font-size:20px;">&times;</div>
     </div>
 </span>
@@ -40,4 +41,21 @@ export default Vue.extend({
   text-align: center;
   font-size: 15px;
 }
+
+#messageLink {
+  text-decoration: none;
+}
+
+#messageLink:link {
+  color:white;
+}
+
+#messageLink:visited {
+  color: white;
+}
+
+#messageLink:hover {
+  color: lightgray;
+}
+
 </style>

--- a/frontend/src/structures/adminMessageUpdate.ts
+++ b/frontend/src/structures/adminMessageUpdate.ts
@@ -5,12 +5,14 @@ export default class AdminMessageUpdate {
     public enabled: boolean;
     public created: Date;
     public updated: Date;
+    public link: string;
 
-    constructor(message: string, enabled: boolean, created: Date, updated: Date) {
+    constructor(message: string, enabled: boolean, created: Date, updated: Date, link: string) {
         this.message = message;
         this.enabled = enabled;
         this.created = created;
         this.updated = updated;
+        this.link = link;
 
     }
 

--- a/frontend/src/structures/serviceproviders/info.service.ts
+++ b/frontend/src/structures/serviceproviders/info.service.ts
@@ -87,9 +87,9 @@ export default class InfoServiceProvider {
 
     public GrabAdminMessage(): Promise<AdminMessageUpdate> {
         return fetch(Resources.BasePath + 'adminMessage').then((data) => data.json()).then((ret) => {
-            return new AdminMessageUpdate(ret.message, Boolean(ret.enabled), new Date(ret.created), new Date(ret.updated));
+            return new AdminMessageUpdate(ret.message, Boolean(ret.enabled), new Date(ret.created), new Date(ret.updated), ret.link);
         }).catch(() => {
-            return new AdminMessageUpdate('', false, new Date(), new Date());
+            return new AdminMessageUpdate('', false, new Date(), new Date(), '');
 
         });
     }

--- a/message.go
+++ b/message.go
@@ -11,7 +11,7 @@ type Message struct {
 	Enabled bool      `json:"enabled"`
 	Created time.Time `json:"created"`
 	Updated time.Time `json:"updated"`
-	Link string       `json:"link"`
+	Link    string    `json:"link"`
 }
 
 // MessageService is an interface for interacting with Messages.

--- a/message.go
+++ b/message.go
@@ -11,6 +11,7 @@ type Message struct {
 	Enabled bool      `json:"enabled"`
 	Created time.Time `json:"created"`
 	Updated time.Time `json:"updated"`
+	Link string       `json:"link"`
 }
 
 // MessageService is an interface for interacting with Messages.

--- a/postgres/message.go
+++ b/postgres/message.go
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS messages (
 	message text,
 	enabled bool NOT NULL,
 	created timestamp with time zone NOT NULL DEFAULT now(),
-	updated timestamp with time zone NOT NULL DEFAULT now()
+	updated timestamp with time zone NOT NULL DEFAULT now(),
+	link text
 );`
 	_, err := ms.db.Exec(schema)
 	return err
@@ -27,10 +28,10 @@ CREATE TABLE IF NOT EXISTS messages (
 
 // Message returns the Message.
 func (ms *MessageService) Message() (*shuttletracker.Message, error) {
-	query := "SELECT message, enabled, created, updated FROM messages;"
+	query := "SELECT message, enabled, created, updated, link FROM messages;"
 	row := ms.db.QueryRow(query)
 	message := &shuttletracker.Message{}
-	err := row.Scan(&message.Message, &message.Enabled, &message.Created, &message.Updated)
+	err := row.Scan(&message.Message, &message.Enabled, &message.Created, &message.Updated, &message.Link)
 	if err == sql.ErrNoRows {
 		return nil, shuttletracker.ErrMessageNotFound
 	} else if err != nil {
@@ -41,9 +42,9 @@ func (ms *MessageService) Message() (*shuttletracker.Message, error) {
 
 // SetMessage updates the Message.
 func (ms *MessageService) SetMessage(message *shuttletracker.Message) error {
-	statement := "INSERT INTO messages (message, enabled, updated) VALUES ($1, $2, now())" +
-		" ON CONFLICT (id) DO UPDATE SET message = excluded.message, enabled = excluded.enabled, updated = excluded.updated" +
+	statement := "INSERT INTO messages (message, enabled, updated, link) VALUES ($1, $2, now(), $3)" +
+		" ON CONFLICT (id) DO UPDATE SET message = excluded.message, enabled = excluded.enabled, updated = excluded.updated, link = excluded.link" +
 		" RETURNING created, updated;"
-	row := ms.db.QueryRow(statement, message.Message, message.Enabled)
+	row := ms.db.QueryRow(statement, message.Message, message.Enabled, message.Link)
 	return row.Scan(&message.Created, &message.Updated)
 }


### PR DESCRIPTION
Added support for a link within an admin message.  A new field in the admin interface was added to enter a link to an outside website.  If an optional website is added, the message contents will become a link to that website within Shuttle Tracker.

close #189 