### PR TITLE
Dark Theme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5101,6 +5101,13 @@
       "integrity": "sha512-5nj7mJeJE81Ai86Zx1YwADugTJcH3w+iY6WDKiMqDohxXWDSE1Mxzfvn5SJqYb4ofc45lU8yTSTYpOMaZCpR/A==",
       "requires": {
         "bulma": "0.7.2"
+      },
+      "dependencies": {
+        "bulma": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.2.tgz",
+          "integrity": "sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ=="
+        }
       }
     },
     "buffer": {
@@ -5145,9 +5152,9 @@
       "dev": true
     },
     "bulma": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.2.tgz",
-      "integrity": "sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.8.0.tgz",
+      "integrity": "sha512-nhf3rGyiZh/VM7FrSJ/5KeLlfaFkXz0nYcXriynfPH4vVpnxnqyEwaNGdNCVzHyyCA3cHgkQAMpdF/SFbFGZfA=="
     },
     "bytes": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@types/webpack-env": "^1.13.9",
     "ajv": "^6.5.4",
     "buefy": "^0.7.2",
-    "bulma": "^0.7.2",
+    "bulma": "^0.8.0",
     "leaflet": "^1.3.4",
     "leaflet-rotatedmarker": "^0.2.0",
     "leaflet-routing-machine": "^3.2.12",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,6 +14,7 @@
 import Vue from 'vue';
 import TabBar from '@/components/tabBar.vue';
 import UserLocationService from '@/structures/userlocation.service';
+import {DarkTheme} from '@/structures/theme';
 
 UserLocationService.getInstance();
 
@@ -21,6 +22,27 @@ export default Vue.extend({
   name: 'app',
   components: {
     TabBar,
+  },
+  computed: {
+    // The theme code is in this file rather than Public.vue because we need the theme to apply to the tab bar and
+    // router tabs as well.
+    currentCSSTheme(): string {
+      return DarkTheme.getCurrentCSSThemeAttribute(this.$store.state);
+    },
+  },
+  watch: {
+    // A watcher is used rather than a bind because we need to put the `data-theme` attribute on <body>, and Vue
+    // cannot bind to the <body> element.
+    // Why? Because inherited CSS properties whose values are a var(...) expression use the context of the inherited
+    // source, not of the inheritor. An example is the color property. <body> has `color: var(...)`. Text elements like
+    // <p> will inherit their color property from <body>. If data-theme is placed below <body>, those <p> elements will
+    // NOT see the updated values of the theme variables because their inherited property comes from <body>.
+    currentCSSTheme: {
+      handler(newValue: string) {
+        document.body.setAttribute('data-theme', newValue);
+      },
+      immediate: true,
+    },
   },
 });
 </script>

--- a/frontend/src/StoreState.ts
+++ b/frontend/src/StoreState.ts
@@ -17,6 +17,7 @@ export interface StoreState {
         etasEnabled: boolean,
         fusionPositionEnabled: boolean,
         busButtonChoice: string,
+        darkThemeMode: string,
     };
     geolocationDenied: boolean;
 

--- a/frontend/src/assets/styles.scss
+++ b/frontend/src/assets/styles.scss
@@ -11,4 +11,5 @@ body {
   right: 0;
   top: 0;
   width: 100%;
+  background: var(--color-bg);
 }

--- a/frontend/src/assets/vars.scss
+++ b/frontend/src/assets/vars.scss
@@ -1,4 +1,5 @@
 @import "~bulma/sass/utilities/all";
+@import "~buefy/src/scss/utils/functions";
 
 /* Master colors definition. */
 $primary: #ed1c24;
@@ -14,6 +15,8 @@ $twitter-invert: findColorInvert($twitter);
  *            a { color: var(--color-primary); }
  * Also defines a var `${name}-rgb` to have only the raw values, for use with functions like rgba().
  *   Example: a { color: rgba(var(--color-primary-rgb), 0.5); }
+ *
+ * https://codyhouse.co/blog/post/how-to-combine-sass-color-functions-and-css-variables
  */
 @mixin defineColor($name, $css-color) {
   #{$name}: #{$css-color};
@@ -22,6 +25,33 @@ $twitter-invert: findColorInvert($twitter);
 @mixin defineColorRGB($name, $red, $green, $blue) {
   #{$name}: unquote("rgb(#{$red}, #{$green}, #{$blue})");
   #{$name}-rgb: unquote("#{$red}, #{$green}, #{$blue}");
+}
+/**
+ * This function overrides the SASS rgba() function to support CSS variables. If a variable is the argument of rgba(),
+ * the built-in CSS rgba() function is used instead.
+ *
+ * BUG! This function will NOT work if the argument is any more complex than a single var(--xxx). Caveat emptor.
+ */
+@function rgba($args...) {
+  // I could not figure out how to call the original rgba function. So.... enjoy this HACK BULLSHIT :(.
+  $color: null;
+  $alpha: null;
+  @if length($args) == 4 {
+    $color: rgb(nth($args, 1), nth($args, 2), nth($args, 3));
+    $alpha: nth($args, 4);
+  } @else {
+    $color: nth($args, 1);
+    $alpha: nth($args, 2);
+  }
+
+  @if type_of($color) == "string" and str-index($color, "var(") == 1 {
+    $color: str-replace($color, "var(", "");
+    $color: str-replace($color, ")");
+    $color: str-replace($color, "-rgb");
+    @return unquote("rgba(var(#{$color}-rgb), #{$alpha})");
+  } @else {
+    @return hsla(hue($color), saturation($color), lightness($color), $alpha);
+  }
 }
 
 /** This is the (default) light theme for the app. These variables are native CSS vars. They are evaluated at runtime. */
@@ -36,7 +66,7 @@ body {
 }
 
 /** This is the dark theme for the app. */
-body[data-theme="dark"] {
+[data-theme="dark"] {
   @include defineColor(--color-fg-strong, $white);
   @include defineColor(--color-fg-normal, darken($white, 15%));
   @include defineColor(--color-fg-light, darken($white, 30%));
@@ -49,12 +79,12 @@ body[data-theme="dark"] {
 $custom-colors: (
     "twitter": ($twitter, $twitter-invert)
 );
-$scheme-main: unquote("var(--color-bg)");
-$scheme-invert: unquote("var(--color-fg-strong)");
-$text-strong: unquote("var(--color-fg-strong)");
-$text: unquote("var(--color-fg-normal)");
-$text-light: unquote("var(--color-fg-light)");
-$text-invert: unquote("var(--color-bg)");
+$scheme-main: var(--color-bg-normal);
+$scheme-invert: var(--color-fg-strong);
+$text-strong: var(--color-fg-strong);
+$text: var(--color-fg-normal);
+$text-light: var(--color-fg-light);
+$text-invert: var(--color-bg-normal);
 
 
 @import "~bulma";

--- a/frontend/src/assets/vars.scss
+++ b/frontend/src/assets/vars.scss
@@ -1,23 +1,60 @@
 @import "~bulma/sass/utilities/all";
 
+/* Master colors definition. */
 $primary: #ed1c24;
 $link: #ff0000;
-$primary-invert: findColorInvert($primary);
+$black: #181818;
+$white: #ffffff;
 $twitter: #4099ff;
 $twitter-invert: findColorInvert($twitter);
 
-$colors: (
-    "white": ($white, $black),
-    "black": ($black, $white),
-    "light": ($light, $light-invert),
-    "dark": ($dark, $dark-invert),
-    "primary": ($primary, $primary-invert),
-    "info": ($info, $info-invert),
-    "success": ($success, $success-invert),
-    "warning": ($warning, $warning-invert),
-    "danger": ($danger, $danger-invert),
+/*
+ * The defineColor* family of functions define a CSS variable `${name}` to be the given color.
+ *   Example: @include defineColorRGB(--color-primary, 0, 255, 0);
+ *            a { color: var(--color-primary); }
+ * Also defines a var `${name}-rgb` to have only the raw values, for use with functions like rgba().
+ *   Example: a { color: rgba(var(--color-primary-rgb), 0.5); }
+ */
+@mixin defineColor($name, $css-color) {
+  #{$name}: #{$css-color};
+  #{$name}-rgb: unquote("#{red($css-color)}, #{green($css-color)}, #{blue($css-color)}");
+}
+@mixin defineColorRGB($name, $red, $green, $blue) {
+  #{$name}: unquote("rgb(#{$red}, #{$green}, #{$blue})");
+  #{$name}-rgb: unquote("#{$red}, #{$green}, #{$blue}");
+}
+
+/** This is the (default) light theme for the app. These variables are native CSS vars. They are evaluated at runtime. */
+body {
+  @include defineColor(--color-fg-strong, $black);
+  @include defineColor(--color-fg-normal, lighten($black, 15%));
+  @include defineColor(--color-fg-light, lighten($black, 30%));
+  @include defineColor(--color-bg-normal, $white);
+  @include defineColor(--color-bg-less, darken($white, 12%));
+  @include defineColor(--color-bg-least, darken($white, 25%));
+  @include defineColor(--color-primary, $primary);
+}
+
+/** This is the dark theme for the app. */
+body[data-theme="dark"] {
+  @include defineColor(--color-fg-strong, $white);
+  @include defineColor(--color-fg-normal, darken($white, 15%));
+  @include defineColor(--color-fg-light, darken($white, 30%));
+  @include defineColor(--color-bg-normal, $black);
+  @include defineColor(--color-bg-less, lighten($black, 12%));
+  @include defineColor(--color-bg-least, lighten($black, 25%));
+}
+
+/** Bulma color overrides. */
+$custom-colors: (
     "twitter": ($twitter, $twitter-invert)
 );
+$scheme-main: unquote("var(--color-bg)");
+$scheme-invert: unquote("var(--color-fg-strong)");
+$text-strong: unquote("var(--color-fg-strong)");
+$text: unquote("var(--color-fg-normal)");
+$text-light: unquote("var(--color-fg-light)");
+$text-invert: unquote("var(--color-bg)");
 
 
 @import "~bulma";

--- a/frontend/src/components/Public.vue
+++ b/frontend/src/components/Public.vue
@@ -365,6 +365,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
+@import "@/assets/vars.scss";
+
 .parent {
   padding: 0px;
   margin: 0px;
@@ -372,6 +374,7 @@ export default Vue.extend({
   position: relative;
   display: flex;
   flex-direction: column;
+  background: var(--color-bg-normal);
 }
 
 input, label{
@@ -396,10 +399,10 @@ input, label{
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  border-bottom: 0.5px solid #eee;
-  box-shadow: 0 -3px 8px 0 #ddd;
+  border-bottom: 0.5px solid var(--color-bg-less);
+  box-shadow: 0 -3px 8px 0 var(--color-bg-least);
   user-select: none;
-  background: white;
+  background: var(--color-bg-normal);
   z-index: 1;
   padding: 0 6px;
 
@@ -423,8 +426,8 @@ input, label{
   div.reconnecting {
     flex: 0 1 auto;
     margin-left: auto;
-    background: linear-gradient(0deg, rgb(250, 250, 250), rgb(240, 240, 240));
-    border: 0.5px solid #eee;
+    background: linear-gradient(0deg, var(--color-bg-less), var(--color-bg-least));
+    border: 0.5px solid var(--color-bg-less);
     padding: 2px 6px;
     border-radius: 4px;
     font-size: 13px;
@@ -462,9 +465,9 @@ input, label{
 }
 
 .info.legend {
-  box-shadow: rgba(0, 0, 0, 0.8) 0px 1px 1px;
+  box-shadow: rgba(var(--color-fg-strong-rgb), 0.8) 0px 1px 1px;
   border-radius: 5px;
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(var(--color-bg-normal-rgb), 0.9);
   padding: 5px;
   bottom: 25px;
   align-content: right;
@@ -478,9 +481,9 @@ input, label{
 }
 
 .info.toggle {
-    box-shadow: rgba(0, 0, 0, 0.8) 0px 1px 1px;
+    box-shadow: rgba(var(--color-fg-strong-rgb), 0.8) 0px 1px 1px;
     border-radius: 5px;
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(var(--color-bg-normal-rgb), 0.9);
     padding: 10px;
     top: 5px;
 
@@ -491,8 +494,8 @@ input, label{
     }
 }
 .button {
-    background: #ee2222;
-    color: white;
+    background: var(--color-primary);
+    color: var(--color-bg-normal);
     float: right;
     border-radius: 1px;
     padding: 0.35em;

--- a/frontend/src/components/busbutton.vue
+++ b/frontend/src/components/busbutton.vue
@@ -11,18 +11,19 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "@/assets/vars.scss";
 
 .bus-button{
     touch-action: manipulation;
-    border: 1px solid #ccc;
+    border: 1px solid var(--color-fg-light);
     border-radius: 50%;
-    box-shadow: 0 4px 8px 0 #ddd;
-    -webkit-box-shadow: 0 4px 8px 0 #ddd;
+    box-shadow: 0 4px 8px 0 var(--color-bg-least);
+    -webkit-box-shadow: 0 4px 8px 0 var(--color-bg-least);
     width: 50px;
     margin: 0;
     padding: 0;
     display: flex;
-    background-color: rgba(250,250,250,.8);
+    background-color: rgba(var(--color-bg-less-rgb), .8);
     justify-content: center;
     align-items: center;
     height: 50px;
@@ -32,7 +33,7 @@ export default Vue.extend({
     outline: 0;
 
     &:hover{
-        background-color: #fff;
+        background-color: var(--color-bg-normal);
     }
 }
 

--- a/frontend/src/components/etaMessage.vue
+++ b/frontend/src/components/etaMessage.vue
@@ -46,6 +46,8 @@ function relativeTime(from: Date, to: Date): string {
 </script>
 
 <style lang="scss" scoped>
+@import "@/assets/vars.scss";
+
 .eta-message {
     width: 320px;
     position: fixed;
@@ -54,11 +56,11 @@ function relativeTime(from: Date, to: Date): string {
     right: 0;
     margin: 60px 20px auto auto;
     z-index: 1000;
-    background: white;
+    background: var(--color-bg-normal);
     padding: 20px 28px;
-    border: 0.5px solid #eee;
+    border: 0.5px solid var(--color-bg-less);
     border-radius: 4px;
-    box-shadow: 0 1px 16px -4px #bbb;
+    box-shadow: 0 1px 16px -4px var(--color-bg-least);
     font-size: 17px;
 }
 @media screen and (max-width: 500px) {

--- a/frontend/src/components/settings.vue
+++ b/frontend/src/components/settings.vue
@@ -34,6 +34,19 @@
       <b-switch v-model="etasEnabled">Estimated times of arrival</b-switch>
     </b-field>
 
+    <div class="field">
+      <b-switch v-model="darkThemeEnabled">Dark theme
+        <div class="control select is-small is-danger is-rounded">
+          <select v-model="darkThemeMode" v-bind:disabled="!darkThemeEnabled">
+            <option v-for="mode in darkThemeAllModes" :value="mode.id">
+              {{mode.description}}
+            </option>
+          </select>
+        </div>
+      </b-switch>
+      <p class="help">Change the theme to Dark across all pages.</p>
+    </div>
+
     <table class="table">
         <thead>
             <tr>
@@ -57,6 +70,7 @@
 import Vue from 'vue';
 import Route from '../structures/route';
 import Public from './Public.vue';
+import {DarkTheme, DarkThemeMode} from '@/structures/theme';
 
 export default Vue.extend({
   name: 'routes',
@@ -76,6 +90,34 @@ export default Vue.extend({
       set(value: string) {
         this.$store.commit('setSettingsBusButtonChoice', value);
       },
+    },
+    // darkThemeEnabled is really just a proxy for darkThemeMode. It makes the UI nicer for people who simply want to
+    // turn it on or off, while still allowing for more advanced dark theme options via the dropdown.
+    darkThemeEnabled: {
+      get(): boolean {
+        return this.$store.state.settings.darkThemeMode !== 'off';
+      },
+      set(value: boolean) {
+        // These assignments will call darkThemeMode.set().
+        if (!value) {
+          // !enabled -> set mode to off
+          this.darkThemeMode = 'off';
+        } else if (this.darkThemeMode === 'off') {
+          // enabled -> ensure mode is not off. This prevents overwriting to 'Always' if the user picks a different mode.
+          this.darkThemeMode = 'on';
+        }
+      },
+    },
+    darkThemeMode: {
+      get(): string {
+        return this.$store.state.settings.darkThemeMode;
+      },
+      set(value: string) {
+        this.$store.commit('setSettingsDarkThemeMode', value);
+      },
+    },
+    darkThemeAllModes(): DarkThemeMode[] {
+      return DarkTheme.allModes;
     },
     fusionPositionEnabled: {
       get(): boolean {

--- a/frontend/src/components/settings.vue
+++ b/frontend/src/components/settings.vue
@@ -117,7 +117,7 @@ export default Vue.extend({
       },
     },
     darkThemeAllModes(): DarkThemeMode[] {
-      return DarkTheme.allModes;
+      return DarkThemeMode.allModes();
     },
     fusionPositionEnabled: {
       get(): boolean {

--- a/frontend/src/components/tabBar.vue
+++ b/frontend/src/components/tabBar.vue
@@ -63,11 +63,11 @@ ul {
   justify-content: center;
   align-items: center;
   width: 100%;
-  border-top: 0.5px solid #eee;
-  box-shadow: 0 3px 8px 0 #ddd;
+  border-top: 0.5px solid var(--color-bg-less);
+  box-shadow: 0 3px 8px 0 var(--color-bg-least);
   font-size: 13px;
   user-select: none;
-  background: white;
+  background: var(--color-bg-normal);
   text-align: center;
 }
 li {
@@ -76,14 +76,14 @@ li {
   height: 100%;
   padding: 5px 15px;
   margin: 0 5px;
-  border-top: 1px solid rgba(0, 0, 0, 0);
+  border-top: 1px solid rgba(var(--color-fg-strong-rgb), 0);
   position: relative;
   top: -0.5px;
   display: flex;
   align-items: center;
 }
 .router-link-exact-active {
-  border-top: 1px solid $primary;
-  color: $primary;
+  border-top: 1px solid var(--color-primary);
+  color: var(--color-primary);
 }
 </style>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -32,6 +32,7 @@ const store: StoreOptions<StoreState> = {
       etasEnabled: false,
       fusionPositionEnabled: true,
       busButtonChoice: '🚌',
+      darkThemeMode: 'off',
     },
     geolocationDenied: false,
     fusionConnected: undefined,
@@ -121,6 +122,10 @@ const store: StoreOptions<StoreState> = {
     },
     setSettingsBusButtonChoice(state, value: string) {
       state.settings.busButtonChoice = value;
+      localStorage.setItem('st_settings', JSON.stringify(state.settings));
+    },
+    setSettingsDarkThemeMode(state, darkThemeId: string) {
+      state.settings.darkThemeMode = darkThemeId;
       localStorage.setItem('st_settings', JSON.stringify(state.settings));
     },
     setSettingsETAsEnabled(state, value: boolean) {

--- a/frontend/src/structures/theme.ts
+++ b/frontend/src/structures/theme.ts
@@ -1,7 +1,55 @@
 import {StoreState} from '@/StoreState';
 
+/**
+ * == How dark theme works in this app ==
+ *
+ * The current theme mode is saved in the global app settings. `state.settings.darkThemeMode`. This mode defines how
+ * the dark theme should be applied. The settings page has a toggle that turns dark theme on or off, and the user can
+ * pick which specific mode they want. The settings logic is in `settings.vue` and `store.ts`.
+ *
+ * The actual theme is implemented via CSS variables and a separate style for dark mode. Elements have their color set
+ * not via a direct color, but by referencing a CSS variable. For example, most text elements have their color as
+ * `color: var(--color-fg-normal)`. In the normal theme, the fg-normal color is black. When the dark theme is enabled,
+ * this variable changes to white. The CSS logic for dark mode is in `theme.ts`.
+ *
+ * Top-level apps have a `data-theme=` attribute on their root element. This attribute controls the current theme of the
+ * app. The value of this attribute is controlled by a computed property that calls {@link DarkTheme#getCurrentCSSThemeAttribute()}.
+ * When the theme is updated from the settings menu, Vue magic happens and this computed property updates to the right
+ * value according to the settings, enabling or disabling the app dark theme.
+ */
+
 /** Describes a dark theme mode. */
 export class DarkThemeMode {
+  public static readonly OFF = new DarkThemeMode('off', 'Off', () => false);
+  public static readonly ON = new DarkThemeMode('on', 'Always', () => true);
+  public static readonly AT_NIGHT = new DarkThemeMode('timeauto', 'At night 🌙',
+    () => {
+      // Simple hour check for nighttime. Future improvement is to use a time library to get the actual sunset and
+      // sunrise times for the local user.
+      const hr = new Date().getHours();
+      return 17 <= hr || hr <= 7;
+    },
+  );
+
+  /**
+   * Every mode defined in this class. Computed dynamically using reflection.
+   */
+  public static allModes(): DarkThemeMode[] {
+    return Object.values(DarkThemeMode)
+      .filter((o) => o instanceof DarkThemeMode);
+  }
+
+  /** Converts a string ID to a {@link DarkThemeMode} object. */
+  public static fromString(darkThemeId: string): DarkThemeMode {
+    // Reflection is used to find every defined DarkThemeMode.
+    const mode = DarkThemeMode.allModes().find((m) => m.id === darkThemeId);
+    if (mode === undefined) {
+      throw new TypeError('Invalid ID :(');
+    } else {
+      return mode;
+    }
+  }
+
   /** The internal ID of this mode. This is how the mode is saved in storage. Should not be edited on existing modes. */
   public readonly id: string;
   /** The name of this mode when seen by the user. */
@@ -18,23 +66,6 @@ export class DarkThemeMode {
 
 /** Holds all valid instances of {@link DarkThemeMode}. */
 export class DarkTheme {
-  public static readonly OFF = new DarkThemeMode('off', 'Off', () => false);
-  public static readonly ON = new DarkThemeMode('on', 'Always', () => true);
-  public static readonly AT_NIGHT = new DarkThemeMode('timeauto', 'At night 🌙',
-    () => {
-      // Simple hour check for nighttime. Future improvement is to use a time library to get the actual sunset and
-      // sunrise times for the local user.
-      const hr = new Date().getHours();
-      return 17 <= hr || hr <= 7;
-    },
-  );
-  /**
-   * Every mode defined in this class. Computed dynamically using reflection.
-   * This MUST come after all instances of {@link DarkThemeMode}.
-   */
-  public static readonly allModes = Object.values(DarkTheme)
-    .filter((o) => o instanceof DarkThemeMode);
-
   /**
    * Determines if the dark theme should be displayed to the user at this time. Anywhere in the site that needs to check
    * the status of dark theme should use this function.
@@ -42,17 +73,23 @@ export class DarkTheme {
    * This is DIFFERENT from checking the mode in {@link StoreState} because some modes are dynamic.
    */
   public static isDarkThemeVisible(state: StoreState): boolean {
-    return this.darkThemeObjFromString(state.settings.darkThemeMode).isDarkThemeVisible();
+    return DarkThemeMode.fromString(state.settings.darkThemeMode).isDarkThemeVisible();
   }
 
-  /** Converts a string ID to a {@link DarkThemeMode} object. */
-  public static darkThemeObjFromString(darkThemeId: string): DarkThemeMode {
-    const mode = DarkTheme.allModes.find((m) => m.id === darkThemeId);
-    if (mode === undefined) {
-      throw new TypeError('Invalid ID :(');
-    } else {
-      return mode;
-    }
+  /**
+   * Computes the appropriate value of the `data-theme` attribute for the currently active theme. Every root
+   * page on the site that is to have a dark theme needs to bind the result of this function to its <body> tag.
+   *
+   * Example:
+   *   computed: {
+   *     ...
+   *     currentCSSTheme(): string {
+   *       return DarkTheme.getCurrentCSSThemeAttribute(this.$store.state);
+   *     },
+   *   },
+   */
+  public static getCurrentCSSThemeAttribute(state: StoreState): string {
+    return DarkTheme.isDarkThemeVisible(state) ? 'dark' : '';
   }
 
   private constructor() {}

--- a/frontend/src/structures/theme.ts
+++ b/frontend/src/structures/theme.ts
@@ -1,0 +1,59 @@
+import {StoreState} from '@/StoreState';
+
+/** Describes a dark theme mode. */
+export class DarkThemeMode {
+  /** The internal ID of this mode. This is how the mode is saved in storage. Should not be edited on existing modes. */
+  public readonly id: string;
+  /** The name of this mode when seen by the user. */
+  public description: string;
+  /** Asks if dark theme should be enabled at this moment. Some modes have dynamic behavior. */
+  public isDarkThemeVisible: () => boolean;
+
+  constructor(id: string, description: string, visibleFn: () => boolean) {
+    this.id = id;
+    this.description = description;
+    this.isDarkThemeVisible = visibleFn;
+  }
+}
+
+/** Holds all valid instances of {@link DarkThemeMode}. */
+export class DarkTheme {
+  public static readonly OFF = new DarkThemeMode('off', 'Off', () => false);
+  public static readonly ON = new DarkThemeMode('on', 'Always', () => true);
+  public static readonly AT_NIGHT = new DarkThemeMode('timeauto', 'At night 🌙',
+    () => {
+      // Simple hour check for nighttime. Future improvement is to use a time library to get the actual sunset and
+      // sunrise times for the local user.
+      const hr = new Date().getHours();
+      return 17 <= hr || hr <= 7;
+    },
+  );
+  /**
+   * Every mode defined in this class. Computed dynamically using reflection.
+   * This MUST come after all instances of {@link DarkThemeMode}.
+   */
+  public static readonly allModes = Object.values(DarkTheme)
+    .filter((o) => o instanceof DarkThemeMode);
+
+  /**
+   * Determines if the dark theme should be displayed to the user at this time. Anywhere in the site that needs to check
+   * the status of dark theme should use this function.
+   *
+   * This is DIFFERENT from checking the mode in {@link StoreState} because some modes are dynamic.
+   */
+  public static isDarkThemeVisible(state: StoreState): boolean {
+    return this.darkThemeObjFromString(state.settings.darkThemeMode).isDarkThemeVisible();
+  }
+
+  /** Converts a string ID to a {@link DarkThemeMode} object. */
+  public static darkThemeObjFromString(darkThemeId: string): DarkThemeMode {
+    const mode = DarkTheme.allModes.find((m) => m.id === darkThemeId);
+    if (mode === undefined) {
+      throw new TypeError('Invalid ID :(');
+    } else {
+      return mode;
+    }
+  }
+
+  private constructor() {}
+}


### PR DESCRIPTION
### What
This PR adds a dark theme to the main app. It is configurable via the settings page. This theme affects everything under `App.vue`, so no admin page dark mode.

### How
Every color in the app stylesheet is replaced with a [CSS variable](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) reference. The master theme variables are switched to either light or dark upon the user changing the theme. `theme.ts` has a detailed documentation of this behavior.
The map tiles are updated via a Vue watcher on current theme. I chose Carto's [Dark Matter](https://openmaptiles.org/styles/#dark-matter) tiles for the dark theme.