### PR TITLE
Dark theme update

### DIFF
--- a/frontend/src/assets/vars.scss
+++ b/frontend/src/assets/vars.scss
@@ -70,6 +70,9 @@ body {
   @include define-color(--color-button-bg, $white);
   @include define-color(--color-button-hover, darken($white, 12%));
   @include define-color(--color-tile-background, #ddd);
+
+  @include define-color(--color-leaflet-background, $white);
+  @include define-color(--color-leaflet-color, $black);
 }
 
 // This is the dark theme for the app.
@@ -92,6 +95,9 @@ body {
   @include define-color(--color-button-bg, lighten($black, 10%));
   @include define-color(--color-button-hover, lighten($black, 14%));
   @include define-color(--color-tile-background, #181818);
+
+  @include define-color(--color-leaflet-background, #181818);
+  @include define-color(--color-leaflet-color, rgba(255,255,255,0.6));
 }
  
 // Bulma color overrides.

--- a/frontend/src/assets/vars.scss
+++ b/frontend/src/assets/vars.scss
@@ -73,6 +73,9 @@ body {
 
   @include define-color(--color-leaflet-background, $white);
   @include define-color(--color-leaflet-color, $black);
+
+  @include define-color(--color-banner-background, #ee2222);
+  @include define-color(--color-banner-color, $white);
 }
 
 // This is the dark theme for the app.
@@ -98,6 +101,11 @@ body {
 
   @include define-color(--color-leaflet-background, #181818);
   @include define-color(--color-leaflet-color, rgba(255,255,255,0.6));
+
+  @include define-color(--color-banner-background, #B30000);
+  @include define-color(--color-banner-color, rgba(255,255,255,0.8));
+
+  // @include define-color(--color-banner-color);
 }
  
 // Bulma color overrides.

--- a/frontend/src/components/Public.vue
+++ b/frontend/src/components/Public.vue
@@ -615,6 +615,12 @@ input, label{
   color: var(--color-fg-light);
   background-color: rgba(var(--color-bg-normal-rgb), 0.7);
 }
+
+.leaflet-popup-content-wrapper {
+  background: var(--color-leaflet-background);
+  color: var(--color-leaflet-color);
+}
+
 #busbutton{
   position: absolute;
   right: 25px;

--- a/frontend/src/components/adminmessage.vue
+++ b/frontend/src/components/adminmessage.vue
@@ -36,8 +36,8 @@ export default Vue.extend({
   left: 0;
   right: 0;
   padding: 10px 30px 10px 15px; /* leave some space for the close button */
-  background: #ee2222;
-  color: #ffffff;
+  background: var(--color-banner-background);
+  color: var(--color-banner-color);
   text-align: center;
   font-size: 15px;
 }

--- a/frontend/src/components/adminmessage.vue
+++ b/frontend/src/components/adminmessage.vue
@@ -23,6 +23,13 @@ export default Vue.extend({
             return this.$store.state.adminMessage;
         },
     },
+    watch: {
+      hide() {
+        if (this.hide) {
+          this.$store.state.adminMessage.enabled = false;
+        }
+      },
+    },
 });
 </script>
 


### PR DESCRIPTION
###### *Do not merge until tested*
## What:  
Added some updates to the Dark Theme that were missed in the initial PR.

## How:
Leaflet icons that open up when clicking on Stops and Shuttles were not dark and are now darkened. The message that admins can display on the ShuttleTracker now has a muted color when on Dark Theme. 

(Changes unrelated to Dark Theme)
Bus button used to disappear when messages were shown by the admin. Bus button now shows up after message is closed by user.

## Included Commits:
&nbsp;

## Is This Related to An Issue? (link if applicable):
&nbsp;

## Additional Notes:
