### PR TITLE
Add input sanitation for bus button emoji choice

### DIFF
--- a/api/fusion.go
+++ b/api/fusion.go
@@ -20,6 +20,8 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
+var validBusButtonEmoji = [...]string{"🚐", "🚌", "🚗", "🚓", "🚜"};
+
 // Messages from clients must be in this envelope. Depending on Type, fusionManager
 // unmarshals Message into the associated type of struct. fusionManager also uses
 // this struct to send messages to clients.
@@ -311,7 +313,12 @@ func (fm *fusionManager) processMessage(cm clientMessage) {
 		fm.handleMsgPosition(fp)
 	case fusionBusButton:
 		fbb := cm.msg.(fusionBusButton)
-		fm.handleMsgBusButton(fbb)
+		for _, emoji := range validBusButtonEmoji {
+				if emoji == fbb.Emoji {
+						fm.handleMsgBusButton(fbb)
+						return
+				}
+		}
 	default:
 		// This is an error since it means that an unhandled message type was sent to
 		// the channel, probably by handleClient. This shouldn't happen, so please fix


### PR DESCRIPTION
###### *Do not merge until tested*
## What:  
&nbsp;

The bus button does not check if the emoji that is being sent is a valid emoji

## How:
&nbsp;

This fixes that issue by checking a list of valid buses and only sending the bus button message if the emoji is in that valid list

## Included Commits:
&nbsp;

[Add input sanitation for bus button emoji choice](https://github.com/wtg/shuttletracker/commit/47a384f5a433ba713e957a6fa57a67f0c55d343f)

## Is This Related to An Issue? (link if applicable):
&nbsp;
no, but we did talk on discord about it

## Additional Notes:
In general, I am confused by this pr template. Could you add some comments to the template that explain what each word is supposed to mean
