### PR TITLE
Added functionality for multiple routes to overlap and be viewable.

### DIFF
--- a/frontend/src/components/Public.vue
+++ b/frontend/src/components/Public.vue
@@ -258,16 +258,17 @@ export default Vue.extend({
         }
       });
       this.existingRouteLayers = new Array<L.Polyline>();
+      let tempWeight = 9;
       this.routePolyLines().forEach((line: L.Polyline) => {
         if (this.Map !== undefined) {
-          console.log(line.options.color);
+          line.options.weight = tempWeight;
+          tempWeight -= Number(9 / this.routePolyLines().length);
           if (DarkTheme.isDarkThemeVisible(this.$store.state)) {
             // mute color
             const darkColor = tinycolor(line.options.color);
             darkColor.darken(15);
-            const newPolyLine = new L.Polyline(line.getLatLngs() as [], {color: line.options.color});
+            const newPolyLine = new L.Polyline(line.getLatLngs() as [], {color: line.options.color, weight: line.options.weight});
             newPolyLine.options.color = darkColor.toString();
-            console.log(newPolyLine.options.color);
             this.Map.addLayer(newPolyLine);
             this.existingRouteLayers.push(newPolyLine);
             return;


### PR DESCRIPTION
###### *Do not merge until tested*
## What is changed/New?  
Functionality added so that when multiple routes are displayed on the Tracker and overlap, the widths of the routes are modified so that they are all viewable (no routes are covered).

## How was this accomplished?
Checker is added to see how many routes are going to be rendered on the map. The larger the amount of routes, the smaller the width change is. 

## Is This Related to An Issue? (link if applicable):
Fixes issue #285  

## Additional Notes:
