### PR TITLE
Smooth tracking predict turns

### DIFF
--- a/smooth/manager.go
+++ b/smooth/manager.go
@@ -36,6 +36,7 @@ func NewConfig(v *viper.Viper) *Config {
 
 	v.SetDefault("smooth.predictupdates", cfg.PredictUpdates)
 	v.SetDefault("smooth.predictioninterval", cfg.PredictionInterval)
+	v.SetDefault("smooth.debugmode", cfg.DebugMode)
 
 	return cfg
 }
@@ -57,6 +58,7 @@ func NewManager(cfg Config, ms shuttletracker.ModelService, updater *updater.Upd
 	}
 	stm.predictionInterval = interval
 	stm.predictUpdates = cfg.PredictUpdates
+	stm.debugMode = cfg.DebugMode
 
 	// Subscribe to new Locations with Updater
 	updater.Subscribe(stm.locationSubscriber)
@@ -88,9 +90,7 @@ func (stm *SmoothTrackingManager) predict() {
 }
 
 // Use the prediction algorithm to make a prediction of this vehicle's current location, create a new location, and send to handleNewPrediction for further processing
-func (stm *SmoothTrackingManager) predictVehiclePosition(vehicleID int64) {
-	log.Debugf("\n\n\n\n\n\nHERE\n\n\n\n\n");
-	
+func (stm *SmoothTrackingManager) predictVehiclePosition(vehicleID int64) {	
 	vehicle, err := stm.ms.Vehicle(vehicleID)
 	if err != nil {
 		log.WithError(err).Errorf("Cannot get vehicle %d for prediction", vehicleID)

--- a/smooth/manager.go
+++ b/smooth/manager.go
@@ -176,5 +176,15 @@ func (stm *SmoothTrackingManager) locationSubscriber(loc *shuttletracker.Locatio
 		log.Debugf("Predicted: %d, (%f, %f)", prediction.Index, prediction.Point.Latitude, prediction.Point.Longitude)
 		log.Debugf("Actual: %d, (%f, %f)", index, loc.Latitude, loc.Longitude)
 		log.Debugf("Difference: %d points or %f meters", diffIndex, diffDistance)
+
+		// add statistics code to calculate stats
+		if stm.debugMode {
+			stm.numDifferences += 1
+			stm.averageDifference = stm.averageDifference + (diffDistance - stm.averageDifference) / float64(stm.numDifferences)
+			log.Debugf("Average Difference is %f", stm.averageDifference)
+			log.Debugf("Number of Differences is %d", stm.numDifferences)
+		}
 	}
+
+	
 }

--- a/smooth/manager.go
+++ b/smooth/manager.go
@@ -89,6 +89,8 @@ func (stm *SmoothTrackingManager) predict() {
 
 // Use the prediction algorithm to make a prediction of this vehicle's current location, create a new location, and send to handleNewPrediction for further processing
 func (stm *SmoothTrackingManager) predictVehiclePosition(vehicleID int64) {
+	log.Debugf("\n\n\n\n\n\nHERE\n\n\n\n\n");
+	
 	vehicle, err := stm.ms.Vehicle(vehicleID)
 	if err != nil {
 		log.WithError(err).Errorf("Cannot get vehicle %d for prediction", vehicleID)

--- a/smooth/manager.go
+++ b/smooth/manager.go
@@ -191,5 +191,9 @@ func (stm *SmoothTrackingManager) locationSubscriber(loc *shuttletracker.Locatio
 		}
 	}
 
-	
+	if stm.debugMode {
+		log.Debugf("Current number of predictions so far is %d", stm.numDifferences)
+		log.Debugf("Average Difference is %f", stm.averageDifference)
+		log.Debugf("Number of Differences is %d", stm.numDifferences)
+	}
 }

--- a/smooth/manager.go
+++ b/smooth/manager.go
@@ -37,13 +37,12 @@ func NewConfig(v *viper.Viper) *Config {
 		PredictUpdates:     true,
 		DebugMode:          true,
 		PredictionInterval: "1s",
-		DebugMode:          true,
 	}
 
 	v.SetDefault("smooth.predictupdates", cfg.PredictUpdates)
 	v.SetDefault("smooth.predictioninterval", cfg.PredictionInterval)
 	v.SetDefault("smooth.debugmode", cfg.DebugMode)
-  
+
 	return cfg
 }
 
@@ -116,7 +115,7 @@ func (stm *SmoothTrackingManager) predict() {
 }
 
 // Use the prediction algorithm to make a prediction of this vehicle's current location, create a new location, and send to handleNewPrediction for further processing
-func (stm *SmoothTrackingManager) predictVehiclePosition(vehicleID int64) {	
+func (stm *SmoothTrackingManager) predictVehiclePosition(vehicleID int64) {
 	vehicle, err := stm.ms.Vehicle(vehicleID)
 	if err != nil {
 		log.WithError(err).Errorf("Cannot get vehicle %d for prediction", vehicleID)
@@ -196,13 +195,6 @@ func (stm *SmoothTrackingManager) locationSubscriber(loc *shuttletracker.Locatio
 
 	// Output comparison between predicted and actual position
 	if exists {
-		diffIndex := int64(math.Abs(float64(prediction.Index - index)))
-		diffDistance := DistanceBetween(prediction.Point, shuttletracker.Point{Latitude: loc.Latitude, Longitude: loc.Longitude})
-		log.Debugf("UPDATED VEHICLE %d", *loc.VehicleID)
-		log.Debugf("Predicted: %d, (%f, %f)", prediction.Index, prediction.Point.Latitude, prediction.Point.Longitude)
-		log.Debugf("Actual: %d, (%f, %f)", index, loc.Latitude, loc.Longitude)
-		log.Debugf("Difference: %d points or %f meters", diffIndex, diffDistance)
-
 		if stm.debugMode {
 			diffIndex := int64(math.Abs(float64(prediction.Index - index)))
 			diffDistance := DistanceBetween(prediction.Point, shuttletracker.Point{Latitude: loc.Latitude, Longitude: loc.Longitude})

--- a/smooth/manager.go
+++ b/smooth/manager.go
@@ -17,20 +17,25 @@ type SmoothTrackingManager struct {
 	predictions        map[int64]*Prediction
 	predictionInterval time.Duration
 	predictUpdates     bool
+	debugMode          bool
 	updates            map[int64]*shuttletracker.Location
 	vehicleIDs         []int64
 	sm                 *sync.Mutex
 	subscribers        []func(Prediction)
+	numDifferences     int
+	averageDifference  float64
 }
 
 type Config struct {
 	PredictionInterval string
 	PredictUpdates     bool
+	DebugMode          bool
 }
 
 func NewConfig(v *viper.Viper) *Config {
 	cfg := &Config{
 		PredictUpdates:     true,
+		DebugMode:          true,
 		PredictionInterval: "1s",
 	}
 

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/wtg/shuttletracker"
+	"github.com/wtg/shuttletracker/log"
 )
 
 type Prediction struct {
@@ -89,7 +90,9 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 	// and stop when the predicted distance has elapsed
 	elapsedDistance := 0.0
 	angle := 0.0
+	prevAngle := 0.0
 	for elapsedDistance < predictedDistance {
+		prevAngle = angle
 		prevIndex := index
 		index++
 		if index >= len(route.Points) {
@@ -97,6 +100,12 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 		}
 		elapsedDistance += DistanceBetween(route.Points[prevIndex], route.Points[index])
 		angle = AngleBetween(route.Points[prevIndex], route.Points[index])
+
+		changeInAngle := math.Abs(angle - prevAngle)
+		if changeInAngle > 40 {
+			log.Debugf("Angles change update is %f", changeInAngle)
+		}
 	}
+
 	return Prediction{VehicleID: vehicle.ID, Point: route.Points[index], Index: index, Angle: angle}
 }

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -118,19 +118,7 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 			// 25, 20, 15, 10-12, or 6-8 MPH
 			// Assuming 6-8 mph is the turning zone (hard to verify with updates being spotty)
 
-			// Concern
-			// Thing is what if a prediction is made and then it doesn't reflect
-			// because the angle doesn't isn't large until it actually already starts the turn and slowed down...
-
-			// Also if the last update's speed is used to calculate the distance to be travelled, it
-			// means that we can change the distance we need to accumulate before the loop ends
-			// but not directly change the speed...
-			// I guess we'll add a certain amount of elapsedDistance
-
-			// Say lastUpdate.Speed = 15 mph, and assuming turn is detected and lasts for 2 seconds
-			// at 8 MPH, we add 7mph * 2 secs = 6.26 meters, so we add 6.26 meters to elapsedDistance
-			// Hard to measure it's impacts unless we run for the entire route as the avg error is
-			// 600-700 meters... The error is so large because updates are so rare...
+			// Change # 1 - Resulted in Avg Difference dropping from 600-700 to 460 meters
 			elapsedDistance += (lastUpdate.Speed - 3.575) * 2 // 8 mph in meters and 2 for # of seconds
 		}
 	}

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/wtg/shuttletracker"
-	"github.com/wtg/shuttletracker/log"
 )
 
 type Prediction struct {
@@ -107,20 +106,17 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 		changeInDistance := elapsedDistance - prevDistance
 
 		if changeInAngle > 50 && changeInAngle < 100 && changeInDistance > 1 { // sharp turn and distance traveled
-			log.Debugf("Predicting a sharp turn...")
-			log.Debugf("Change in angle is %f for vehicle %d", changeInAngle, vehicle.ID)
-			log.Debugf("Current Speed is %f for vehicle %d", lastUpdate.Speed, vehicle.ID)
-			log.Debugf("Change in distance is %f", changeInDistance)
-
-			// Plan is to drop speed to 6-8 mph when a sharp turn is detected
-			// Avg Error is 600-700 meters without this change
-			// Running the webapp 3 times found the shuttle speeds to predominantly be
-			// 25, 20, 15, 10-12, or 6-8 MPH
-			// Assuming 6-8 mph is the turning zone (hard to verify with updates being spotty)
-
 			// Change # 1 - Resulted in Avg Difference dropping from 600-700 to 460 meters
 			elapsedDistance += (lastUpdate.Speed - 3.575) * 2 // 8 mph in meters and 2 for # of seconds
 		}
+
+		// Stops -
+		// Using stop ids and the route, I can calculate how far the shuttle is to the next stop on the route
+		// and set it so that when it is close to the stops, we update
+		// the distance
+		// I'll have to see how long red lights last and if we can
+		// get the average wait time at a stop
+		// For lights, we'll have to do way more testing.
 	}
 
 	return Prediction{VehicleID: vehicle.ID, Point: route.Points[index], Index: index, Angle: angle}

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -105,7 +105,7 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 		changeInAngle := math.Abs(math.Mod(angle, 360.0) - math.Mod(prevAngle, 360.0))
 		changeInDistance := elapsedDistance - prevDistance
 
-		if changeInAngle > 50 && changeInAngle < 100 && changeInDistance > 1 { // sharp turn and distance traveled
+		if changeInAngle > 50 && changeInAngle < 100 && changeInDistance > 1 && lastUpdate.Speed > 3.6 { // sharp turn and distance traveled
 			// Change # 1 - Resulted in Avg Difference dropping from 600-700 to 460 meters
 			elapsedDistance += (lastUpdate.Speed - 3.575) * 2 // 8 mph in meters and 2 for # of seconds
 		}

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -121,6 +121,17 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 			// Concern
 			// Thing is what if a prediction is made and then it doesn't reflect
 			// because the angle doesn't isn't large until it actually already starts the turn and slowed down...
+
+			// Also if the last update's speed is used to calculate the distance to be travelled, it
+			// means that we can change the distance we need to accumulate before the loop ends
+			// but not directly change the speed...
+			// I guess we'll add a certain amount of elapsedDistance
+
+			// Say lastUpdate.Speed = 15 mph, and assuming turn is detected and lasts for 2 seconds
+			// at 8 MPH, we add 7mph * 2 secs = 6.26 meters, so we add 6.26 meters to elapsedDistance
+			// Hard to measure it's impacts unless we run for the entire route as the avg error is
+			// 600-700 meters... The error is so large because updates are so rare...
+			elapsedDistance += (lastUpdate.Speed - 3.575) * 2 // 8 mph in meters and 2 for # of seconds
 		}
 	}
 

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -104,12 +104,23 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 		angle = AngleBetween(route.Points[prevIndex], route.Points[index])
 
 		changeInAngle := math.Abs(math.Mod(angle, 360.0) - math.Mod(prevAngle, 360.0))
+		changeInDistance := elapsedDistance - prevDistance
 
-		if changeInAngle > 50 && changeInAngle < 100 {
+		if changeInAngle > 50 && changeInAngle < 100 && changeInDistance > 1 { // sharp turn and distance traveled
 			log.Debugf("Predicting a sharp turn...")
 			log.Debugf("Change in angle is %f for vehicle %d", changeInAngle, vehicle.ID)
 			log.Debugf("Current Speed is %f for vehicle %d", lastUpdate.Speed, vehicle.ID)
-			log.Debugf("Change in distance is %f", elapsedDistance-prevDistance)
+			log.Debugf("Change in distance is %f", changeInDistance)
+
+			// Plan is to drop speed to 6-8 mph when a sharp turn is detected
+			// Avg Error is 600-700 meters without this change
+			// Running the webapp 3 times found the shuttle speeds to predominantly be
+			// 25, 20, 15, 10-12, or 6-8 MPH
+			// Assuming 6-8 mph is the turning zone (hard to verify with updates being spotty)
+
+			// Concern
+			// Thing is what if a prediction is made and then it doesn't reflect
+			// because the angle doesn't isn't large until it actually already starts the turn and slowed down...
 		}
 	}
 

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -91,9 +91,11 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 	elapsedDistance := 0.0
 	angle := 0.0
 	prevAngle := 0.0
+	prevDistance := 0.0
 	for elapsedDistance < predictedDistance {
 		prevAngle = angle
 		prevIndex := index
+		prevDistance = elapsedDistance
 		index++
 		if index >= len(route.Points) {
 			index = 0
@@ -103,29 +105,12 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 
 		changeInAngle := math.Abs(math.Mod(angle, 360.0) - math.Mod(prevAngle, 360.0))
 
-		if changeInAngle > 50 {
-			log.Debugf("PrevAngle is %f", math.Mod(prevAngle, 360.0))
-			log.Debugf("Angle is %f", math.Mod(angle, 360.0))
-			log.Debugf("Angles change update is %f for vehicle: %d", changeInAngle, vehicle.ID)
+		if changeInAngle > 50 && changeInAngle < 100 {
+			log.Debugf("Predicting a sharp turn...")
+			log.Debugf("Change in angle is %f for vehicle %d", changeInAngle, vehicle.ID)
+			log.Debugf("Current Speed is %f for vehicle %d", lastUpdate.Speed, vehicle.ID)
+			log.Debugf("Change in distance is %f", elapsedDistance-prevDistance)
 		}
-
-		/*  For some reason Angle ends up becoming 0 every other iteration...
-		DEBU[0031] PrevAngle is 0.000000                         file=smooth_tracking.go line=107 package=smooth
-		DEBU[0031] Angle is 271.670941                           file=smooth_tracking.go line=108 package=smooth
-		DEBU[0031] Angles change update is 271.670941 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
-		DEBU[0031] PrevAngle is 270.000005                       file=smooth_tracking.go line=107 package=smooth
-		DEBU[0031] Angle is 0.000000                             file=smooth_tracking.go line=108 package=smooth
-		DEBU[0031] Angles change update is 270.000005 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
-		DEBU[0031] PrevAngle is 0.000000                         file=smooth_tracking.go line=107 package=smooth
-		DEBU[0031] Angle is 259.826909                           file=smooth_tracking.go line=108 package=smooth
-		DEBU[0031] Angles change update is 259.826909 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
-		DEBU[0031] PrevAngle is 262.612982                       file=smooth_tracking.go line=107 package=smooth
-		DEBU[0031] Angle is 0.000000                             file=smooth_tracking.go line=108 package=smooth
-		DEBU[0031] Angles change update is 262.612982 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
-		DEBU[0031] PrevAngle is 0.000000                         file=smooth_tracking.go line=107 package=smooth
-		DEBU[0031] Angle is 270.000000                           file=smooth_tracking.go line=108 package=smooth
-		DEBU[0031] Angles change update is 270.000000 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
-		*/
 	}
 
 	return Prediction{VehicleID: vehicle.ID, Point: route.Points[index], Index: index, Angle: angle}

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -109,14 +109,6 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 			// Change # 1 - Resulted in Avg Difference dropping from 600-700 to 460 meters
 			elapsedDistance += (lastUpdate.Speed - 3.575) * 2 // 8 mph in meters and 2 for # of seconds
 		}
-
-		// Stops -
-		// Using stop ids and the route, I can calculate how far the shuttle is to the next stop on the route
-		// and set it so that when it is close to the stops, we update
-		// the distance
-		// I'll have to see how long red lights last and if we can
-		// get the average wait time at a stop
-		// For lights, we'll have to do way more testing.
 	}
 
 	return Prediction{VehicleID: vehicle.ID, Point: route.Points[index], Index: index, Angle: angle}

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -103,9 +103,29 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 
 		changeInAngle := math.Abs(math.Mod(angle, 360.0) - math.Mod(prevAngle, 360.0))
 
-		log.Debugf("PrevAngle is %f", math.Mod(prevAngle, 360.0))
-		log.Debugf("Angle is %f", math.Mod(angle, 360.0))
-		log.Debugf("Angles change update is %f", changeInAngle)
+		if changeInAngle > 50 {
+			log.Debugf("PrevAngle is %f", math.Mod(prevAngle, 360.0))
+			log.Debugf("Angle is %f", math.Mod(angle, 360.0))
+			log.Debugf("Angles change update is %f for vehicle: %d", changeInAngle, vehicle.ID)
+		}
+
+		/*  For some reason Angle ends up becoming 0 every other iteration...
+		DEBU[0031] PrevAngle is 0.000000                         file=smooth_tracking.go line=107 package=smooth
+		DEBU[0031] Angle is 271.670941                           file=smooth_tracking.go line=108 package=smooth
+		DEBU[0031] Angles change update is 271.670941 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
+		DEBU[0031] PrevAngle is 270.000005                       file=smooth_tracking.go line=107 package=smooth
+		DEBU[0031] Angle is 0.000000                             file=smooth_tracking.go line=108 package=smooth
+		DEBU[0031] Angles change update is 270.000005 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
+		DEBU[0031] PrevAngle is 0.000000                         file=smooth_tracking.go line=107 package=smooth
+		DEBU[0031] Angle is 259.826909                           file=smooth_tracking.go line=108 package=smooth
+		DEBU[0031] Angles change update is 259.826909 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
+		DEBU[0031] PrevAngle is 262.612982                       file=smooth_tracking.go line=107 package=smooth
+		DEBU[0031] Angle is 0.000000                             file=smooth_tracking.go line=108 package=smooth
+		DEBU[0031] Angles change update is 262.612982 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
+		DEBU[0031] PrevAngle is 0.000000                         file=smooth_tracking.go line=107 package=smooth
+		DEBU[0031] Angle is 270.000000                           file=smooth_tracking.go line=108 package=smooth
+		DEBU[0031] Angles change update is 270.000000 for vehicle: 4  file=smooth_tracking.go line=109 package=smooth
+		*/
 	}
 
 	return Prediction{VehicleID: vehicle.ID, Point: route.Points[index], Index: index, Angle: angle}

--- a/smooth/smooth_tracking.go
+++ b/smooth/smooth_tracking.go
@@ -101,10 +101,11 @@ func NaivePredictPosition(vehicle *shuttletracker.Vehicle, lastUpdate *shuttletr
 		elapsedDistance += DistanceBetween(route.Points[prevIndex], route.Points[index])
 		angle = AngleBetween(route.Points[prevIndex], route.Points[index])
 
-		changeInAngle := math.Abs(angle - prevAngle)
-		if changeInAngle > 40 {
-			log.Debugf("Angles change update is %f", changeInAngle)
-		}
+		changeInAngle := math.Abs(math.Mod(angle, 360.0) - math.Mod(prevAngle, 360.0))
+
+		log.Debugf("PrevAngle is %f", math.Mod(prevAngle, 360.0))
+		log.Debugf("Angle is %f", math.Mod(angle, 360.0))
+		log.Debugf("Angles change update is %f", changeInAngle)
 	}
 
 	return Prediction{VehicleID: vehicle.ID, Point: route.Points[index], Index: index, Angle: angle}


### PR DESCRIPTION
###### *Do not merge until tested*

## What is changed/New?  
Added a change that decreases the distance the prediction travels when a turn is detected.

## How was this accomplished?
How exactly did you make this change/fix?
I ran the web app a few times and logged the data. Now I see that the speed for turns is probably 6-8 MPH. Therefore, I just correct the distance needed to travel whenever a turn is detected.

## Additional Notes:
This may not be the best change, but it does decrease the average error by 200 meters.