### PR TITLE
Update package-lock.json for shuttle slide.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10704,6 +10704,11 @@
         "osrm-text-instructions": "^0.13.2"
       }
     },
+    "leaflet.marker.slideto": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet.marker.slideto/-/leaflet.marker.slideto-0.2.0.tgz",
+      "integrity": "sha1-AZGnE0yFq1fR3Y7+/JCrvlKYiOk="
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -11913,7 +11918,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {


### PR DESCRIPTION
###### *Do not merge until tested*
## What is changed/New?  
Updating package-lock.json so that it contains the information required to push the master branch of Shuttle Tracker to the dokku-server.

## How was this accomplished?
How exactly did you make this change/fix?
Calling npm install in the frontend branch to update dependencies then pushing the updated package-lock.json to branch.

## Is This Related to An Issue? (link if applicable):
Was this related to an issue provided on the Issues page? Link it the issue if it is.

## Additional Notes:
