### PR TITLE
Update off-route shuttle headings when shuttle sliding is enabled

### DIFF
--- a/frontend/src/structures/vehicle.ts
+++ b/frontend/src/structures/vehicle.ts
@@ -112,7 +112,7 @@ export default class Vehicle {
     }
 
     public setHeading(heading: number) {
-        if (!store.state.settings.shuttleSlideEnabled) {
+        if (!store.state.settings.shuttleSlideEnabled || this.pointIndex == null || this.endPointIndex == null) {
             this.marker.setRotationAngle(heading - 45);
             this.marker.bindPopup(this.getMessage());
         } else {


### PR DESCRIPTION
###### *Do not merge until tested*
## What is changed/New?  
Fixed a bug that caused headings, and also pop-ups as a result, to not update for off-route shuttles when shuttle sliding is enabled.

## How was this accomplished?
Added a check for the existence of a closest point or destination point, indicating whether shuttle sliding will occur, when determining whether to immediately update a shuttle's heading.

## Is This Related to An Issue? (link if applicable):
N/A

## Additional Notes:
N/A