### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,5 @@
 !frontend
 frontend/node_modules
 frontend/dist
+!conf.json
+!spoof_data


### PR DESCRIPTION
###### *Do not merge until tested*
## What is changed/New?  
Updated `.dockerignore` to not ignore the config file and the spoof data folder. This is necessary to run Shuttle Tracker in spoof mode after building with Docker.

## How was this accomplished?
Added a couple lines to `.dockerignore`.

## Is This Related to An Issue? (link if applicable):
N/A

## Additional Notes:
N/A