### PR TITLE
Import stops and vehicles from JSON

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -109,20 +109,16 @@ func (api *API) StopsCreateHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	if stop.ID < 0 {
 		err = api.ms.CreateStop(stop)
-		if err != nil {
-			log.WithError(err).Error("unable to create stop")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
 	} else {
 		err = api.ms.CreateStopWithID(stop)
-		if err != nil {
-			log.WithError(err).Error("unable to create stop")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	}
+	if err != nil {
+		log.WithError(err).Error("unable to create stop")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	WriteJSON(w, stop)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -109,11 +109,20 @@ func (api *API) StopsCreateHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	err = api.ms.CreateStop(stop)
-	if err != nil {
-		log.WithError(err).Error("unable to create stop")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	if stop.ID < 0 {
+		err = api.ms.CreateStop(stop)
+		if err != nil {
+			log.WithError(err).Error("unable to create stop")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		err = api.ms.CreateStopWithID(stop)
+		if err != nil {
+			log.WithError(err).Error("unable to create stop")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 	WriteJSON(w, stop)
 }

--- a/frontend/src/components/admin/vehiclesAdmin.vue
+++ b/frontend/src/components/admin/vehiclesAdmin.vue
@@ -26,6 +26,20 @@
                     <th></th>
                     <th><button @click="$router.push('/admin/vehicles/-1/new')" class="button is-success">New</button></th>
                 </tr>
+                <div class="file">
+                  <label class="file-label">
+                    <input class="file-input" type="file" name="import" @change="handleFileUpload">
+                    <span class="file-cta">
+                      <span class="file-icon">
+                        <img src="./../../assets/upload-icon.svg"></i>
+                      </span>
+                      <span class="file-label">
+                        Choose a file…
+                      </span>
+                    </span>
+                  </label>
+                  <button v-on:click="addImportedVehicles()" class="button is-success">Submit</button>
+                </div>
             </tbody>
         </table>
     </div>
@@ -47,9 +61,11 @@ export default Vue.extend({
         return{
             shouldDelete: false,
             vehicleToDelete: undefined,
+            file: null,
         } as {
             shouldDelete: boolean,
             vehicleToDelete: Vehicle | undefined,
+            file: any,
         };
     },
     components: {
@@ -66,6 +82,50 @@ export default Vue.extend({
                     this.$store.dispatch('grabVehicles');
                 });
             }
+        },
+
+        addImportedVehicles() {
+          const reader = new FileReader();
+          let json = null;
+          // Capture file information
+          reader.onload = ((theFile) => {
+            return (e: any) => {
+              try {
+                json = JSON.parse(e.target.result);
+                // If JSON.parse does not return a usable value, throw an Error
+                if (json.length === undefined || json.length === 0) {
+                  throw new Error('Improper JSON formatting');
+                }
+                for (let i = 0; i < json.length; i++) {
+                    const obj = json[i];
+                    // Create a new Vehicle object using the data in obj
+                    const newVehicle = new Vehicle(obj.id, obj.name, obj.created, obj.updated, obj.enabled, obj.tracker_id);
+                    // If creating the new Vehicle failed, the JSON file was not formatted correctly. Throw an Error
+                    if (!newVehicle) {
+                      throw new Error('Improper JSON formatting');
+                    }
+                    // Create the vehicle in the database
+                    AdminServiceProvider.NewVehicle(newVehicle).then(() => {
+                            this.$store.dispatch('grabVehicles');
+                    });
+                }
+              } catch (e) {
+                // If we get a SyntaxError, we have received a Non-JSON file. Replace the error to reflect this.
+                if (e instanceof SyntaxError) {
+                  e = new Error('Non-JSON file submitted');
+                }
+                // Display the Error to the user, and log it in the console
+                alert(e);
+                console.log(e);
+              }
+            };
+          })(this.file);
+          reader.readAsText(this.file);
+        },
+
+        // Gets the user-submitted file and stores it
+        handleFileUpload(event: any) {
+          this.file = event.target.files[0];
         },
     },
 });

--- a/frontend/src/structures/stop.ts
+++ b/frontend/src/structures/stop.ts
@@ -89,9 +89,9 @@ export class Stop {
     }
 
     public asJSON(): {
-        name: string; description: string; latitude: number; longitude: number } {
+        id: number, name: string; description: string; latitude: number; longitude: number } {
         return {
-            // id: this.id,
+            id: this.id,
             name: this.name,
             description: this.description,
             latitude: Number(this.latitude),

--- a/postgres/stop.go
+++ b/postgres/stop.go
@@ -35,6 +35,13 @@ func (ss *StopService) CreateStop(stop *shuttletracker.Stop) error {
 	return row.Scan(&stop.ID, &stop.Created, &stop.Updated)
 }
 
+func (ss *StopService) CreateStopWithID(stop *shuttletracker.Stop) error {
+	statement := "INSERT INTO stops (id, name, description, latitude, longitude) VALUES" +
+		" ($1, $2, $3, $4, $5) RETURNING id, created, updated;"
+	row := ss.db.QueryRow(statement, stop.ID, stop.Name, stop.Description, stop.Latitude, stop.Longitude)
+	return row.Scan(&stop.ID, &stop.Created, &stop.Updated)
+}
+
 // Stop returns a Stop by its ID.
 func (ss *StopService) Stop(id int64) (*shuttletracker.Stop, error) {
 	s := &shuttletracker.Stop{

--- a/stop.go
+++ b/stop.go
@@ -23,6 +23,7 @@ type StopService interface {
 	Stop(id int64) (*Stop, error)
 	Stops() ([]*Stop, error)
 	CreateStop(stop *Stop) error
+	CreateStopWithID(stop *Stop) error
 	DeleteStop(id int64) error
 }
 


### PR DESCRIPTION
###### *Do not merge until tested*
## What is changed/New?
Stops and vehicles can now be imported from JSON files through the admin panel, in the same way that routes could already be.

## How was this accomplished?
Added a file chooser to the stops and vehicles admin panel tabs that parses objects and inserts them into the database when a file is submitted.

## Is This Related to An Issue? (link if applicable):
N/A

## Additional Notes:
When stops are imported, they use the stop IDs from the JSON file rather than relying on the auto-incrementing serial column, so that they are associated with the correct routes.